### PR TITLE
fix: print proper pricing per page(s)

### DIFF
--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -19,6 +19,7 @@ interface PrintConfig {
   orientation: Orientation;
   paperSize: PaperSize;
   pageRange: PageRangeSelection;
+  totalPages: number;
 }
 
 interface PreviewConfig {
@@ -776,6 +777,7 @@ continueBtn?.addEventListener("click", () => {
     orientation: cfg.orientation,
     paperSize: cfg.paperSize,
     pageRange: getPageRange(),
+    totalPages: preview.pageCount,
   };
 
   sessionStorage.setItem("printbit.mode", mode);

--- a/src/public/confirm/app.ts
+++ b/src/public/confirm/app.ts
@@ -21,6 +21,7 @@ type ConfirmConfig = {
   orientation: 'portrait' | 'landscape';
   paperSize: 'A4' | 'Letter' | 'Legal';
   pageRange?: PageRangeSelection;
+  totalPages?: number;
 };
 
 type PricingResponse = {
@@ -94,6 +95,27 @@ function pageRangeLabel(sel?: PageRangeSelection): string {
   return sel.range ? `Pages ${sel.range}` : 'Pages (custom)';
 }
 
+function countPrintPages(): number {
+  const total = config.totalPages ?? 1;
+  const range = config.pageRange;
+  if (!range || range.type === "all") return total;
+  if (range.type === "single") return 1;
+  let count = 0;
+  for (const part of range.range.split(",")) {
+    const trimmed = part.trim();
+    const m = trimmed.match(/^(\d+)\s*-\s*(\d+)$/);
+    if (m) {
+      const from = Math.max(1, parseInt(m[1], 10));
+      const to = Math.min(total, parseInt(m[2], 10));
+      if (from <= to) count += to - from + 1;
+    } else {
+      const p = parseInt(trimmed, 10);
+      if (!isNaN(p) && p >= 1 && p <= total) count += 1;
+    }
+  }
+  return Math.max(1, count);
+}
+
 function calculateTotalPrice(pricing: PricingResponse): number {
   if (config.mode === 'scan') {
     return pricing.scanDocument ?? DEFAULT_PRICING.scanDocument;
@@ -101,7 +123,8 @@ function calculateTotalPrice(pricing: PricingResponse): number {
   const base =
     config.mode === 'copy' ? pricing.copyPerPage : pricing.printPerPage;
   const color = config.colorMode === 'colored' ? pricing.colorSurcharge : 0;
-  return (base + color) * Math.max(1, config.copies);
+  const pages = config.mode === "print" ? countPrintPages() : 1;
+  return (base + color) * pages * Math.max(1, config.copies);
 }
 
 if (confirmBtn) {


### PR DESCRIPTION
This pull request introduces several improvements to the PrintBit kiosk startup scripts and enhances the accuracy of print page counting and pricing in the print confirmation flow. The main themes are improved kiosk startup automation (with dynamic IP detection and PowerShell support) and more accurate calculation of print pages and pricing.

**Kiosk Startup Automation:**

* Added a new PowerShell script (`scripts/start-kiosk.ps1`) that self-elevates to administrator, starts the PrintBit server, waits for it to be ready, dynamically detects the local IP address, and launches Microsoft Edge in kiosk mode pointed at the correct URL. This improves reliability and ease of use for Windows users.
* Added a batch launcher (`scripts/run.bat`) to simplify starting the kiosk via double-click, automatically invoking the PowerShell script with elevation.
* Updated `scripts/start-kiosk.bat` to dynamically detect the local IP address, construct the kiosk URL accordingly, and launch Edge in kiosk mode at the correct address, falling back to `localhost` if necessary. [[1]](diffhunk://#diff-f16570543c52b09105309b341709b4287357189d9d7c46753198e26e5726f0d5R31-R48) [[2]](diffhunk://#diff-f16570543c52b09105309b341709b4287357189d9d7c46753198e26e5726f0d5L39-R61)
* Updated `package.json` scripts to include a `start` command for launching the kiosk via the new batch script.

**Print Page Counting and Pricing:**

* Enhanced the print confirmation logic to accurately count the number of pages being printed based on the selected page range, and updated price calculation to reflect the true number of pages. This includes passing the total page count from the preview step to the confirmation step and using it in calculations. [[1]](diffhunk://#diff-13ba37108da83b84908058f309342d4fd3c3f6f9a8674c95d190640f81e6dc12R22) [[2]](diffhunk://#diff-13ba37108da83b84908058f309342d4fd3c3f6f9a8674c95d190640f81e6dc12R780) [[3]](diffhunk://#diff-b71b0fae66f015c7e65156c4d5a9732c2e04857d1f8249bd0366bb62d91c764eR24) [[4]](diffhunk://#diff-b71b0fae66f015c7e65156c4d5a9732c2e04857d1f8249bd0366bb62d91c764eR98-R127)