### PR TITLE
fix: missing open badge mob

### DIFF
--- a/src/public/admin/feedback/app.ts
+++ b/src/public/admin/feedback/app.ts
@@ -31,7 +31,7 @@ const statTotal = document.getElementById('statTotal') as HTMLElement;
 const statOpen = document.getElementById('statOpen') as HTMLElement;
 const statResolved = document.getElementById('statResolved') as HTMLElement;
 const openBadge = document.getElementById('openBadge') as HTMLElement;
-const openBadgeMob = document.getElementById('openBadgeMob') as HTMLElement;
+const openBadgeMob = document.getElementById('openBadgeMob') as HTMLElement | null;
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -76,7 +76,7 @@ function updateStats(): void {
   statResolved.textContent = String(resolvedCount);
   const badgeText = openCount > 0 ? String(openCount) : '';
   openBadge.textContent = badgeText;
-  openBadgeMob.textContent = badgeText;
+  if (openBadgeMob) openBadgeMob.textContent = badgeText;
 }
 
 // ── Rendering ───────────────────────────────────────────────────────────────

--- a/src/public/admin/feedback/index.html
+++ b/src/public/admin/feedback/index.html
@@ -452,6 +452,11 @@
           />
         </svg>
         <span>Feedback</span>
+        <span
+          class="nav-count-badge"
+          id="openBadgeMob"
+          aria-label="open feedback count"
+        ></span>
       </a>
       <a href="/admin/report" class="mob-nav__btn">
         <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feedback count badge to the navigation bar, displaying the number of open feedback items in both desktop and mobile views.

* **Bug Fixes**
  * Improved feedback count badge handling for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->