### PR TITLE
refactor: improve apiRouter validation in createApiAwareApp function

### DIFF
--- a/src/runtime/api-aware-app.ts
+++ b/src/runtime/api-aware-app.ts
@@ -37,7 +37,10 @@ export function createApiAwareApp(
   apiRouter: unknown,
   apiBasePath: string,
 ): Express {
-  if (!apiRouter || typeof apiRouter !== 'object') {
+  if (
+    !apiRouter ||
+    (typeof apiRouter !== 'function' && typeof apiRouter !== 'object')
+  ) {
     throw new Error('apiRouter must be a valid Express Router');
   }
 


### PR DESCRIPTION
This pull request makes a minor update to the input validation logic in the `createApiAwareApp` function to ensure that `apiRouter` can be either an object or a function, which aligns better with how Express Routers are implemented.

- Validation improvement:
  * Updated the `createApiAwareApp` function in `src/runtime/api-aware-app.ts` to accept both objects and functions as valid `apiRouter` types, improving compatibility with Express Router implementations.