### PR TITLE
feat: implement kiosk lockdown features and disable USB export in lockdown mode

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -245,7 +245,6 @@ Runs an interactive scan for the `/scan` page and returns preview page URLs + fi
 
 **Body parameters:**
 
-- `source` — `"feeder"` (ADF document feeder) or `"glass"` (flatbed scanner glass). **Required.**
 - `color` — `"color"` or `"grayscale"`. **Required.**
 - `dpi` — `150`, `300`, or `600`. **Required.**
 
@@ -253,9 +252,22 @@ Runs an interactive scan for the `/scan` page and returns preview page URLs + fi
 
 Lists currently detected removable USB drives.
 
+When kiosk lockdown disables USB export (`PRINTBIT_USB_EXPORT_ENABLED=false`, or `PRINTBIT_KIOSK_LOCKDOWN=true` with no override), this endpoint returns:
+
+```json
+{
+  "code": "USB_EXPORT_DISABLED",
+  "error": "USB export is disabled in kiosk lockdown mode. Use wireless QR download instead."
+}
+```
+
+with HTTP `423`.
+
 ### `POST /api/scanner/wired/export`
 
 Exports a scanned file from `uploads/scans` to a selected removable USB drive.
+
+When USB export is disabled by lockdown config, this endpoint returns the same `423` blocked response described above.
 
 ### `POST /api/scanner/wireless-link`
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -59,7 +59,7 @@
 
 - Check scanner readiness from `GET /api/scanner/status`.
 - For wireless delivery, regenerate the link from `POST /api/scanner/wireless-link` and retry `/scan/download/:token`.
-- For USB delivery, verify removable drive detection via `GET /api/scanner/wired/drives` before calling `POST /api/scanner/wired/export`.
+- In kiosk lockdown mode, USB export routes are disabled and return `423` with `code: "USB_EXPORT_DISABLED"`.
 
 ## Storage and state safety
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,12 @@ Troubleshooting:
 5. Tap **Get Soft Copy**.
 6. Choose delivery:
    - **Wireless (QR):** scan the generated QR code to download.
-   - **USB Flash Drive:** insert a USB drive, refresh, then export.
 
 Troubleshooting:
 
 - If scanner is unavailable, check scanner connection/power and retry.
 - If the QR link expires, refresh the wireless link.
-- If no USB is detected, insert/reinsert the drive and refresh.
+- USB mass storage is disabled in kiosk lockdown mode by design.
 
 ## Tech stack
 

--- a/WINDOWS_KIOSK_LOCKDOWN_SETUP.md
+++ b/WINDOWS_KIOSK_LOCKDOWN_SETUP.md
@@ -1,0 +1,125 @@
+# Windows Kiosk Lockdown Setup & Installation Guide (Issue #38)
+
+This guide is for preparing a **Windows tablet** for PrintBit kiosk deployment with lockdown controls.
+
+## 1) Target environment
+
+- Windows 10/11 tablet (kiosk device)
+- Dedicated kiosk local user account
+- Separate admin/service account for maintenance
+
+## 2) Required software and drivers
+
+Install these first:
+
+- Node.js 20.x LTS
+- pnpm `10.13.1`
+- Git
+- Microsoft Edge (latest stable)
+- `bin/SumatraPDF.exe` present in project
+- MyPublicWiFi
+- Printer driver package (production printer)
+- Scanner driver + NAPS2 (`C:\Program Files\NAPS2\NAPS2.Console.exe`)
+- Serial/USB drivers for coin acceptor / hopper controller
+
+## 3) PrintBit app installation
+
+From the project root:
+
+```powershell
+pnpm install
+pnpm run build
+pnpm exec tsc --noEmit
+```
+
+Validate launcher scripts exist:
+
+- `scripts\start-kiosk.ps1`
+- `scripts\start-kiosk.bat`
+- `scripts\install-startup.ps1`
+
+## 4) Startup automation
+
+Run as Administrator:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\install-startup.ps1
+```
+
+This installs the scheduled task `PrintBit Kiosk` for auto-start at login.
+
+## 5) Lockdown policy target (planned profile)
+
+For Issue #38, target these controls:
+
+- Use **Assigned Access (single-app kiosk)** as primary shell restriction
+- Disable escape vectors (task switching/start/task manager/settings/system tray where policy allows)
+- Suppress notifications/action center popups
+- Block USB mass storage at OS level
+- Keep PrintBit scan delivery on wireless/QR path (USB export disabled in lockdown)
+
+## 5.1) App lockdown environment flags
+
+Set these environment values on kiosk startup:
+
+- `PRINTBIT_KIOSK_LOCKDOWN=true`
+- `PRINTBIT_USB_EXPORT_ENABLED=false`
+
+These are already set by `scripts\run.bat` and defaulted by kiosk startup scripts.
+
+## 5.2) Apply / verify / revert lockdown scripts
+
+Run as Administrator from project root:
+
+```powershell
+pnpm run lockdown:apply
+pnpm run lockdown:verify
+```
+
+For maintenance windows:
+
+```powershell
+pnpm run lockdown:revert
+```
+
+Then re-apply and verify before returning the device to public use.
+
+## 6) Assigned Access setup checklist (tablet)
+
+1. Create/sign in dedicated kiosk user.
+2. Configure Assigned Access to Edge kiosk experience for PrintBit URL.
+3. Ensure PrintBit startup task works under kiosk login.
+4. Reboot and verify kiosk returns directly to locked app flow.
+
+## 7) Development-phase rehearsal (before tablet transfer)
+
+Run a rehearsal on a Windows dev machine:
+
+1. Apply lockdown profile in test user context.
+2. Launch kiosk via `scripts\run.bat` or scheduled task.
+3. Verify users cannot escape to desktop/settings/system tools.
+4. Verify print/copy/scan core flows still work.
+5. Verify USB mass storage is blocked and scan USB export is unavailable.
+6. Record pass/fail and remediation notes.
+
+## 8) Validation checklist
+
+- Kiosk auto-start works after reboot
+- PrintBit reachable in kiosk mode
+- Alt+Tab/Win-key/task switching vectors blocked (as supported by edition/policy)
+- Notifications do not disrupt kiosk flow
+- Settings/Task Manager inaccessible for kiosk user
+- USB storage blocked
+- Core transaction flow (upload, pay, print) still succeeds
+
+## 9) Maintenance / break-glass expectations
+
+- Use admin/service account only for updates and troubleshooting.
+- Keep a documented rollback path to temporarily relax lockdown for servicing.
+- Re-apply lockdown after maintenance and re-run validation checklist.
+
+## 10) Notes
+
+- Shell Launcher can be considered only if Windows edition supports it and Assigned Access is insufficient.
+- This guide is paired with `plan.md` tasks for implementing scripts, app-level USB gating, and formal verification artifacts.
+- `apply-kiosk-lockdown.ps1` includes an optional `-DisableWinKeys` flag to apply Scancode Map key blocking (requires reboot).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "dev": "ts-node-dev -r tsconfig-paths/register src/server.ts",
     "build": "node scripts/build-client.js",
     "kiosk": "node ./scripts/launch-kiosk.js",
-    "start": "cmd /c ./scripts/start-kiosk.bat"
+    "start": "cmd /c ./scripts/start-kiosk.bat",
+    "install-startup": "powershell -ExecutionPolicy Bypass -File .\\scripts\\install-startup.ps1",
+    "lockdown:apply": "powershell -ExecutionPolicy Bypass -File .\\scripts\\apply-kiosk-lockdown.ps1",
+    "lockdown:verify": "powershell -ExecutionPolicy Bypass -File .\\scripts\\verify-kiosk-lockdown.ps1",
+    "lockdown:revert": "powershell -ExecutionPolicy Bypass -File .\\scripts\\revert-kiosk-lockdown.ps1"
   },
   "keywords": [],
   "author": "GioMjds",

--- a/scripts/apply-kiosk-lockdown.ps1
+++ b/scripts/apply-kiosk-lockdown.ps1
@@ -77,7 +77,8 @@ Set-DwordValue -Path $legacySystem   -Name 'DisableTaskMgr' -Value 1
 # USB mass-storage hardening
 Ensure-RegistryKey -Path $printBitState
 $existingUsbStorStart = Get-DwordValueOrNull -Path $usbStor -Name 'Start'
-if ($null -ne $existingUsbStorStart) {
+$savedUsbStorStart = Get-DwordValueOrNull -Path $printBitState -Name 'UsbStorStartOriginal'
+if ($null -eq $savedUsbStorStart -and $null -ne $existingUsbStorStart) {
   Set-DwordValue -Path $printBitState -Name 'UsbStorStartOriginal' -Value $existingUsbStorStart
 }
 Set-DwordValue -Path $usbStor          -Name 'Start'    -Value 4

--- a/scripts/apply-kiosk-lockdown.ps1
+++ b/scripts/apply-kiosk-lockdown.ps1
@@ -21,6 +21,8 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$helpersModule = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'kiosk-helpers.psm1'
+Import-Module $helpersModule -Force
 
 function Ensure-RegistryKey {
   param([Parameter(Mandatory = $true)][string]$Path)
@@ -47,20 +49,6 @@ function Set-BinaryValue {
   )
   Ensure-RegistryKey -Path $Path
   New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType Binary -Force | Out-Null
-}
-
-function Get-DwordValueOrNull {
-  param(
-    [Parameter(Mandatory = $true)][string]$Path,
-    [Parameter(Mandatory = $true)][string]$Name
-  )
-  if (-not (Test-Path $Path)) { return $null }
-  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
-  if ($null -eq $item) { return $null }
-  if ($item.PSObject.Properties.Name -contains $Name) {
-    return [int]$item.$Name
-  }
-  return $null
 }
 
 $policyExplorer    = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'

--- a/scripts/apply-kiosk-lockdown.ps1
+++ b/scripts/apply-kiosk-lockdown.ps1
@@ -49,6 +49,20 @@ function Set-BinaryValue {
   New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType Binary -Force | Out-Null
 }
 
+function Get-DwordValueOrNull {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  if (-not (Test-Path $Path)) { return $null }
+  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+  if ($null -eq $item) { return $null }
+  if ($item.PSObject.Properties.Name -contains $Name) {
+    return [int]$item.$Name
+  }
+  return $null
+}
+
 $policyExplorer    = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
 $policySystem      = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
 $legacyExplorer    = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
@@ -73,6 +87,11 @@ Set-DwordValue -Path $policySystem   -Name 'DisableCMD'     -Value 1
 Set-DwordValue -Path $legacySystem   -Name 'DisableTaskMgr' -Value 1
 
 # USB mass-storage hardening
+Ensure-RegistryKey -Path $printBitState
+$existingUsbStorStart = Get-DwordValueOrNull -Path $usbStor -Name 'Start'
+if ($null -ne $existingUsbStorStart) {
+  Set-DwordValue -Path $printBitState -Name 'UsbStorStartOriginal' -Value $existingUsbStorStart
+}
 Set-DwordValue -Path $usbStor          -Name 'Start'    -Value 4
 Set-DwordValue -Path $removablePolicy  -Name 'Deny_All' -Value 1
 

--- a/scripts/apply-kiosk-lockdown.ps1
+++ b/scripts/apply-kiosk-lockdown.ps1
@@ -1,0 +1,105 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+  Applies PrintBit Windows kiosk lockdown policies.
+
+.DESCRIPTION
+  Enables OS-level restrictions for kiosk deployments:
+  - Disable notifications and tray interactions
+  - Restrict Settings/Control Panel and Task Manager
+  - Block common escape shortcuts where policy supports it
+  - Block USB mass storage access
+  - Optionally disable Windows keys through Scancode Map
+
+  A reboot is recommended after applying.
+#>
+
+[CmdletBinding()]
+param(
+  [switch]$DisableWinKeys
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-RegistryKey {
+  param([Parameter(Mandatory = $true)][string]$Path)
+  if (-not (Test-Path $Path)) {
+    New-Item -Path $Path -Force | Out-Null
+  }
+}
+
+function Set-DwordValue {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][int]$Value
+  )
+  Ensure-RegistryKey -Path $Path
+  New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType DWord -Force | Out-Null
+}
+
+function Set-BinaryValue {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][byte[]]$Value
+  )
+  Ensure-RegistryKey -Path $Path
+  New-ItemProperty -Path $Path -Name $Name -Value $Value -PropertyType Binary -Force | Out-Null
+}
+
+$policyExplorer    = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+$policySystem      = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
+$legacyExplorer    = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+$legacySystem      = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$usbStor           = 'HKLM:\SYSTEM\CurrentControlSet\Services\USBSTOR'
+$removablePolicy   = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\RemovableStorageDevices'
+$keyboardLayout    = 'HKLM:\SYSTEM\CurrentControlSet\Control\Keyboard Layout'
+$printBitState     = 'HKLM:\SOFTWARE\PrintBit\KioskLockdown'
+
+Write-Host "[PrintBit] Applying kiosk lockdown policy..." -ForegroundColor Cyan
+
+# Notification / tray hardening
+Set-DwordValue -Path $policyExplorer -Name 'DisableNotificationCenter' -Value 1
+Set-DwordValue -Path $policyExplorer -Name 'NoTrayContextMenu'         -Value 1
+Set-DwordValue -Path $policyExplorer -Name 'NoTrayItemsDisplay'        -Value 1
+
+# Settings / shell / shortcut hardening
+Set-DwordValue -Path $legacyExplorer -Name 'NoControlPanel' -Value 1
+Set-DwordValue -Path $legacyExplorer -Name 'NoWinKeys'      -Value 1
+Set-DwordValue -Path $legacyExplorer -Name 'NoAltTab'       -Value 1
+Set-DwordValue -Path $policySystem   -Name 'DisableCMD'     -Value 1
+Set-DwordValue -Path $legacySystem   -Name 'DisableTaskMgr' -Value 1
+
+# USB mass-storage hardening
+Set-DwordValue -Path $usbStor          -Name 'Start'    -Value 4
+Set-DwordValue -Path $removablePolicy  -Name 'Deny_All' -Value 1
+
+if ($DisableWinKeys) {
+  # Disable Left Win (E05B), Right Win (E05C), and Apps/Menu key (E05D).
+  $scancodeMap = [byte[]](
+    0x00,0x00,0x00,0x00,
+    0x00,0x00,0x00,0x00,
+    0x04,0x00,0x00,0x00,
+    0x00,0x00,0x5B,0xE0,
+    0x00,0x00,0x5C,0xE0,
+    0x00,0x00,0x5D,0xE0,
+    0x00,0x00,0x00,0x00
+  )
+  Set-BinaryValue -Path $keyboardLayout -Name 'Scancode Map' -Value $scancodeMap
+  Write-Host "[PrintBit] Win keys and Apps key disabled via Scancode Map." -ForegroundColor Yellow
+}
+
+Ensure-RegistryKey -Path $printBitState
+Set-DwordValue -Path $printBitState -Name 'Applied' -Value 1
+New-ItemProperty -Path $printBitState -Name 'AppliedAtUtc' -Value ([DateTime]::UtcNow.ToString('o')) -PropertyType String -Force | Out-Null
+New-ItemProperty -Path $printBitState -Name 'Version'      -Value '1' -PropertyType String -Force | Out-Null
+
+Write-Host ""
+Write-Host "[PrintBit] [OK] Lockdown policies applied."  -ForegroundColor Green
+Write-Host "[PrintBit]   Recommended next steps:"        -ForegroundColor Cyan
+Write-Host "[PrintBit]   1) Configure Assigned Access (single-app kiosk)." -ForegroundColor Gray
+Write-Host "[PrintBit]   2) Reboot the device."                            -ForegroundColor Gray
+Write-Host "[PrintBit]   3) Run scripts\verify-kiosk-lockdown.ps1."        -ForegroundColor Gray
+Write-Host ""

--- a/scripts/install-startup.ps1
+++ b/scripts/install-startup.ps1
@@ -32,7 +32,7 @@ if ($Uninstall) {
         Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
         Write-Host "[PrintBit] Scheduled task '$TaskName' removed." -ForegroundColor Green
     } else {
-        Write-Host "[PrintBit] Task '$TaskName' not found — nothing to remove." -ForegroundColor Yellow
+        Write-Host "[PrintBit] Task '$TaskName' not found -- nothing to remove." -ForegroundColor Yellow
     }
     return
 }
@@ -50,7 +50,7 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
 
 $Action = New-ScheduledTaskAction `
     -Execute "cmd.exe" `
-    -Argument "/c `"$BatPath`"" `
+    -Argument ("/c `"" + $BatPath + "`"") `
     -WorkingDirectory (Split-Path $BatPath)
 
 $Trigger = New-ScheduledTaskTrigger -AtLogOn
@@ -77,7 +77,7 @@ Register-ScheduledTask `
     -Description "Starts PrintBit server with MyPublicWiFi hotspot on login." | Out-Null
 
 Write-Host ""
-Write-Host "[PrintBit] ✓ Scheduled task '$TaskName' installed!" -ForegroundColor Green
+Write-Host "[PrintBit] Scheduled task '$TaskName' installed!" -ForegroundColor Green
 Write-Host "[PrintBit]   Runs at logon as $env:USERNAME with admin privileges." -ForegroundColor Cyan
 Write-Host "[PrintBit]   To remove: .\scripts\install-startup.ps1 -Uninstall" -ForegroundColor DarkGray
 Write-Host ""

--- a/scripts/kiosk-helpers.psm1
+++ b/scripts/kiosk-helpers.psm1
@@ -1,0 +1,19 @@
+Set-StrictMode -Version Latest
+
+function Get-DwordValueOrNull {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  if (-not (Test-Path $Path)) { return $null }
+  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+  if ($null -eq $item) { return $null }
+  if ($item.PSObject.Properties.Name -contains $Name) {
+    return [int]$item.$Name
+  }
+  return $null
+}
+
+Export-ModuleMember -Function Get-DwordValueOrNull

--- a/scripts/revert-kiosk-lockdown.ps1
+++ b/scripts/revert-kiosk-lockdown.ps1
@@ -1,0 +1,64 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+  Reverts PrintBit Windows kiosk lockdown policies for maintenance.
+
+.DESCRIPTION
+  Restores policy values changed by apply-kiosk-lockdown.ps1.
+  A reboot is recommended after revert.
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Remove-RegistryValueIfExists {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  if (-not (Test-Path $Path)) { return }
+  $value = Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue
+  if ($null -ne $value) {
+    Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction SilentlyContinue
+  }
+}
+
+$policyExplorer   = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+$policySystem     = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
+$legacyExplorer   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+$legacySystem     = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$usbStor          = 'HKLM:\SYSTEM\CurrentControlSet\Services\USBSTOR'
+$removablePolicy  = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\RemovableStorageDevices'
+$keyboardLayout   = 'HKLM:\SYSTEM\CurrentControlSet\Control\Keyboard Layout'
+$printBitState    = 'HKLM:\SOFTWARE\PrintBit\KioskLockdown'
+
+Write-Host "[PrintBit] Reverting kiosk lockdown policy..." -ForegroundColor Cyan
+
+Remove-RegistryValueIfExists -Path $policyExplorer -Name 'DisableNotificationCenter'
+Remove-RegistryValueIfExists -Path $policyExplorer -Name 'NoTrayContextMenu'
+Remove-RegistryValueIfExists -Path $policyExplorer -Name 'NoTrayItemsDisplay'
+Remove-RegistryValueIfExists -Path $legacyExplorer -Name 'NoControlPanel'
+Remove-RegistryValueIfExists -Path $legacyExplorer -Name 'NoWinKeys'
+Remove-RegistryValueIfExists -Path $legacyExplorer -Name 'NoAltTab'
+Remove-RegistryValueIfExists -Path $policySystem   -Name 'DisableCMD'
+Remove-RegistryValueIfExists -Path $legacySystem   -Name 'DisableTaskMgr'
+Remove-RegistryValueIfExists -Path $removablePolicy -Name 'Deny_All'
+
+if (Test-Path $usbStor) {
+  New-ItemProperty -Path $usbStor -Name 'Start' -Value 3 -PropertyType DWord -Force | Out-Null
+}
+
+Remove-RegistryValueIfExists -Path $keyboardLayout -Name 'Scancode Map'
+
+if (Test-Path $printBitState) {
+  New-ItemProperty -Path $printBitState -Name 'Applied'       -Value 0 -PropertyType DWord -Force | Out-Null
+  New-ItemProperty -Path $printBitState -Name 'RevertedAtUtc' -Value ([DateTime]::UtcNow.ToString('o')) -PropertyType String -Force | Out-Null
+}
+
+Write-Host ""
+Write-Host "[PrintBit] [OK] Lockdown policies reverted for maintenance."           -ForegroundColor Green
+Write-Host "[PrintBit]   Reboot recommended, then re-apply lockdown before deployment." -ForegroundColor Yellow
+Write-Host ""

--- a/scripts/revert-kiosk-lockdown.ps1
+++ b/scripts/revert-kiosk-lockdown.ps1
@@ -13,6 +13,8 @@ param()
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$helpersModule = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'kiosk-helpers.psm1'
+Import-Module $helpersModule -Force
 
 function Remove-RegistryValueIfExists {
   param(
@@ -24,20 +26,6 @@ function Remove-RegistryValueIfExists {
   if ($null -ne $value) {
     Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction SilentlyContinue
   }
-}
-
-function Get-DwordValueOrNull {
-  param(
-    [Parameter(Mandatory = $true)][string]$Path,
-    [Parameter(Mandatory = $true)][string]$Name
-  )
-  if (-not (Test-Path $Path)) { return $null }
-  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
-  if ($null -eq $item) { return $null }
-  if ($item.PSObject.Properties.Name -contains $Name) {
-    return [int]$item.$Name
-  }
-  return $null
 }
 
 $policyExplorer   = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
@@ -64,6 +52,7 @@ Remove-RegistryValueIfExists -Path $removablePolicy -Name 'Deny_All'
 if (Test-Path $usbStor) {
   $restoredStart = Get-DwordValueOrNull -Path $printBitState -Name 'UsbStorStartOriginal'
   if ($null -eq $restoredStart) {
+    Write-Warning "[PrintBit] Missing persisted UsbStorStartOriginal in '$printBitState'. Applying fallback Start=3 to '$usbStor'."
     $restoredStart = 3
   }
   New-ItemProperty -Path $usbStor -Name 'Start' -Value ([int]$restoredStart) -PropertyType DWord -Force | Out-Null

--- a/scripts/revert-kiosk-lockdown.ps1
+++ b/scripts/revert-kiosk-lockdown.ps1
@@ -26,6 +26,20 @@ function Remove-RegistryValueIfExists {
   }
 }
 
+function Get-DwordValueOrNull {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  if (-not (Test-Path $Path)) { return $null }
+  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+  if ($null -eq $item) { return $null }
+  if ($item.PSObject.Properties.Name -contains $Name) {
+    return [int]$item.$Name
+  }
+  return $null
+}
+
 $policyExplorer   = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
 $policySystem     = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
 $legacyExplorer   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
@@ -48,12 +62,17 @@ Remove-RegistryValueIfExists -Path $legacySystem   -Name 'DisableTaskMgr'
 Remove-RegistryValueIfExists -Path $removablePolicy -Name 'Deny_All'
 
 if (Test-Path $usbStor) {
-  New-ItemProperty -Path $usbStor -Name 'Start' -Value 3 -PropertyType DWord -Force | Out-Null
+  $restoredStart = Get-DwordValueOrNull -Path $printBitState -Name 'UsbStorStartOriginal'
+  if ($null -eq $restoredStart) {
+    $restoredStart = 3
+  }
+  New-ItemProperty -Path $usbStor -Name 'Start' -Value ([int]$restoredStart) -PropertyType DWord -Force | Out-Null
 }
 
 Remove-RegistryValueIfExists -Path $keyboardLayout -Name 'Scancode Map'
 
 if (Test-Path $printBitState) {
+  Remove-RegistryValueIfExists -Path $printBitState -Name 'UsbStorStartOriginal'
   New-ItemProperty -Path $printBitState -Name 'Applied'       -Value 0 -PropertyType DWord -Force | Out-Null
   New-ItemProperty -Path $printBitState -Name 'RevertedAtUtc' -Value ([DateTime]::UtcNow.ToString('o')) -PropertyType String -Force | Out-Null
 }

--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -4,4 +4,6 @@
 :: Runs start-kiosk.ps1 with auto-elevation.
 :: No need to open PowerShell manually.
 :: ─────────────────────────────────────────────────────────────────
+set "PRINTBIT_KIOSK_LOCKDOWN=true"
+set "PRINTBIT_USB_EXPORT_ENABLED=false"
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0start-kiosk.ps1"

--- a/scripts/start-kiosk.bat
+++ b/scripts/start-kiosk.bat
@@ -57,7 +57,7 @@ echo [PrintBit] Kiosk URL: %KIOSK_URL%
 
 :: Start PrintBit server (this also launches MyPublicWiFi + hotspot)
 echo [PrintBit] Starting server...
-start "PrintBit Server" /min cmd /c "cd /d ""%PROJECT_DIR%"" && set ""PRINTBIT_KIOSK_LOCKDOWN=%PRINTBIT_KIOSK_LOCKDOWN%"" && set ""PRINTBIT_USB_EXPORT_ENABLED=%PRINTBIT_USB_EXPORT_ENABLED%"" && pnpm run dev"
+start "PrintBit Server" /min cmd /c "pushd ""%PROJECT_DIR%"" && set PRINTBIT_KIOSK_LOCKDOWN=%PRINTBIT_KIOSK_LOCKDOWN% && set PRINTBIT_USB_EXPORT_ENABLED=%PRINTBIT_USB_EXPORT_ENABLED% && pnpm run dev"
 
 :: Wait for server to come up
 echo [PrintBit] Waiting for server to start...

--- a/scripts/start-kiosk.bat
+++ b/scripts/start-kiosk.bat
@@ -25,6 +25,21 @@ if "%PRINTBIT_USB_EXPORT_ENABLED%"=="" set "PRINTBIT_USB_EXPORT_ENABLED=false"
 echo [PrintBit] Kiosk Lockdown: %PRINTBIT_KIOSK_LOCKDOWN%
 echo [PrintBit] USB Export Enabled: %PRINTBIT_USB_EXPORT_ENABLED%
 
+setlocal EnableDelayedExpansion
+set "PROJECT_DIR_SANITIZED=%PROJECT_DIR%"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:^!=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:&=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:|=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:<=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:>=!"
+if not "%PROJECT_DIR%"=="!PROJECT_DIR_SANITIZED!" (
+    echo [PrintBit] ERROR: Project path contains unsupported shell metacharacters (^& ^| ^< ^> ^!).
+    echo [PrintBit]        Use a controlled deployment path without these characters.
+    pause
+    exit /b 1
+)
+endlocal & set "PROJECT_DIR=%PROJECT_DIR_SANITIZED%"
+
 :: Ensure pnpm is available
 where pnpm >nul 2>&1
 if %errorlevel% neq 0 (

--- a/scripts/start-kiosk.bat
+++ b/scripts/start-kiosk.bat
@@ -27,13 +27,14 @@ echo [PrintBit] USB Export Enabled: %PRINTBIT_USB_EXPORT_ENABLED%
 
 setlocal EnableDelayedExpansion
 set "PROJECT_DIR_SANITIZED=%PROJECT_DIR%"
-set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:^!=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:^^=!"
 set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:&=!"
 set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:|=!"
 set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:<=!"
 set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:>=!"
+set "PROJECT_DIR_SANITIZED=!PROJECT_DIR_SANITIZED:%%=!"
 if not "%PROJECT_DIR%"=="!PROJECT_DIR_SANITIZED!" (
-    echo [PrintBit] ERROR: Project path contains unsupported shell metacharacters (^& ^| ^< ^> ^!).
+    echo [PrintBit] ERROR: Project path contains unsupported shell metacharacters (^& ^| ^< ^> ^! %%).
     echo [PrintBit]        Use a controlled deployment path without these characters.
     pause
     exit /b 1

--- a/scripts/start-kiosk.bat
+++ b/scripts/start-kiosk.bat
@@ -20,6 +20,11 @@ cd /d "%~dp0.."
 set "PROJECT_DIR=%cd%"
 echo [PrintBit] Project: %PROJECT_DIR%
 
+if "%PRINTBIT_KIOSK_LOCKDOWN%"=="" set "PRINTBIT_KIOSK_LOCKDOWN=true"
+if "%PRINTBIT_USB_EXPORT_ENABLED%"=="" set "PRINTBIT_USB_EXPORT_ENABLED=false"
+echo [PrintBit] Kiosk Lockdown: %PRINTBIT_KIOSK_LOCKDOWN%
+echo [PrintBit] USB Export Enabled: %PRINTBIT_USB_EXPORT_ENABLED%
+
 :: Ensure pnpm is available
 where pnpm >nul 2>&1
 if %errorlevel% neq 0 (
@@ -52,7 +57,7 @@ echo [PrintBit] Kiosk URL: %KIOSK_URL%
 
 :: Start PrintBit server (this also launches MyPublicWiFi + hotspot)
 echo [PrintBit] Starting server...
-start "PrintBit Server" /min cmd /c "cd /d "%PROJECT_DIR%" && pnpm run dev"
+start "PrintBit Server" /min cmd /c "cd /d ""%PROJECT_DIR%"" && set ""PRINTBIT_KIOSK_LOCKDOWN=%PRINTBIT_KIOSK_LOCKDOWN%"" && set ""PRINTBIT_USB_EXPORT_ENABLED=%PRINTBIT_USB_EXPORT_ENABLED%"" && pnpm run dev"
 
 :: Wait for server to come up
 echo [PrintBit] Waiting for server to start...

--- a/scripts/start-kiosk.ps1
+++ b/scripts/start-kiosk.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     PrintBit Kiosk Startup Script
     Self-elevates to Administrator, starts the PrintBit server,

--- a/scripts/start-kiosk.ps1
+++ b/scripts/start-kiosk.ps1
@@ -28,6 +28,8 @@ if (-not $isAdmin) {
 $ScriptsDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectDir  = Split-Path -Parent $ScriptsDir
 $Port        = "3000"
+$kioskLockdown = if ($env:PRINTBIT_KIOSK_LOCKDOWN) { $env:PRINTBIT_KIOSK_LOCKDOWN } else { 'true' }
+$usbExportEnabled = if ($env:PRINTBIT_USB_EXPORT_ENABLED) { $env:PRINTBIT_USB_EXPORT_ENABLED } else { 'false' }
 
 Write-Host ""
 Write-Host "╔══════════════════════════════════════════╗" -ForegroundColor Cyan
@@ -36,6 +38,8 @@ Write-Host "╚═════════════════════�
 Write-Host ""
 Write-Host "[PrintBit] Project  : $ProjectDir"  -ForegroundColor Gray
 Write-Host "[PrintBit] Port     : $Port"         -ForegroundColor Gray
+Write-Host "[PrintBit] Lockdown : $kioskLockdown" -ForegroundColor Gray
+Write-Host "[PrintBit] USB Export Enabled : $usbExportEnabled" -ForegroundColor Gray
 Write-Host ""
 
 # ── 3. VERIFY DEPENDENCIES ───────────────────────────────────────────────────
@@ -60,7 +64,7 @@ if (-not (Test-Path $edgePath)) {
 Write-Host "[PrintBit] Starting server (pnpm run dev)..." -ForegroundColor Green
 
 $serverProc = Start-Process cmd.exe `
-    -ArgumentList "/c cd /d `"$ProjectDir`" && pnpm run dev" `
+    -ArgumentList "/c cd /d `"$ProjectDir`" && set PRINTBIT_KIOSK_LOCKDOWN=$kioskLockdown && set PRINTBIT_USB_EXPORT_ENABLED=$usbExportEnabled && pnpm run dev" `
     -WindowStyle Minimized `
     -PassThru
 

--- a/scripts/verify-kiosk-lockdown.ps1
+++ b/scripts/verify-kiosk-lockdown.ps1
@@ -1,0 +1,91 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+  Verifies PrintBit Windows kiosk lockdown posture.
+
+.DESCRIPTION
+  Checks registry-based lockdown indicators and prints PASS/FAIL per control.
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-DwordOrNull {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+  if (-not (Test-Path $Path)) { return $null }
+  $item = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+  if ($null -eq $item) { return $null }
+  if ($item.PSObject.Properties.Name -contains $Name) {
+    return [int]$item.$Name
+  }
+  return $null
+}
+
+function Write-Check {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][bool]$Passed,
+    [Parameter(Mandatory = $true)][string]$Detail
+  )
+  $prefix = if ($Passed) { '[PASS]' } else { '[FAIL]' }
+  $color  = if ($Passed) { 'Green' } else { 'Red' }
+  Write-Host "$prefix $Name - $Detail" -ForegroundColor $color
+}
+
+$checks = @()
+
+$policyExplorer  = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+$policySystem    = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
+$legacyExplorer  = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+$legacySystem    = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$usbStor         = 'HKLM:\SYSTEM\CurrentControlSet\Services\USBSTOR'
+$removablePolicy = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\RemovableStorageDevices'
+$printBitState   = 'HKLM:\SOFTWARE\PrintBit\KioskLockdown'
+
+$disableNotificationCenter = Get-DwordOrNull -Path $policyExplorer  -Name 'DisableNotificationCenter'
+$noTrayContextMenu         = Get-DwordOrNull -Path $policyExplorer  -Name 'NoTrayContextMenu'
+$noTrayItemsDisplay        = Get-DwordOrNull -Path $policyExplorer  -Name 'NoTrayItemsDisplay'
+$noControlPanel            = Get-DwordOrNull -Path $legacyExplorer  -Name 'NoControlPanel'
+$noWinKeys                 = Get-DwordOrNull -Path $legacyExplorer  -Name 'NoWinKeys'
+$noAltTab                  = Get-DwordOrNull -Path $legacyExplorer  -Name 'NoAltTab'
+$disableTaskMgr            = Get-DwordOrNull -Path $legacySystem    -Name 'DisableTaskMgr'
+$disableCmd                = Get-DwordOrNull -Path $policySystem    -Name 'DisableCMD'
+$usbStorStart              = Get-DwordOrNull -Path $usbStor         -Name 'Start'
+$denyAllRemovable          = Get-DwordOrNull -Path $removablePolicy -Name 'Deny_All'
+$applied                   = Get-DwordOrNull -Path $printBitState   -Name 'Applied'
+
+$checks += [pscustomobject]@{ Name = 'Notifications disabled';        Passed = ($disableNotificationCenter -eq 1); Detail = "DisableNotificationCenter=$disableNotificationCenter" }
+$checks += [pscustomobject]@{ Name = 'Tray context blocked';          Passed = ($noTrayContextMenu -eq 1);         Detail = "NoTrayContextMenu=$noTrayContextMenu" }
+$checks += [pscustomobject]@{ Name = 'Tray items hidden';             Passed = ($noTrayItemsDisplay -eq 1);        Detail = "NoTrayItemsDisplay=$noTrayItemsDisplay" }
+$checks += [pscustomobject]@{ Name = 'Settings/Control Panel blocked';Passed = ($noControlPanel -eq 1);           Detail = "NoControlPanel=$noControlPanel" }
+$checks += [pscustomobject]@{ Name = 'Windows shortcut keys blocked'; Passed = ($noWinKeys -eq 1);                Detail = "NoWinKeys=$noWinKeys" }
+$checks += [pscustomobject]@{ Name = 'Alt+Tab blocked';               Passed = ($noAltTab -eq 1);                 Detail = "NoAltTab=$noAltTab" }
+$checks += [pscustomobject]@{ Name = 'Task Manager blocked';          Passed = ($disableTaskMgr -eq 1);           Detail = "DisableTaskMgr=$disableTaskMgr" }
+$checks += [pscustomobject]@{ Name = 'Command prompt blocked';        Passed = ($disableCmd -eq 1);               Detail = "DisableCMD=$disableCmd" }
+$checks += [pscustomobject]@{ Name = 'USB storage service disabled';  Passed = ($usbStorStart -eq 4);             Detail = "USBSTOR.Start=$usbStorStart" }
+$checks += [pscustomobject]@{ Name = 'Removable storage denied';      Passed = ($denyAllRemovable -eq 1);         Detail = "Deny_All=$denyAllRemovable" }
+$checks += [pscustomobject]@{ Name = 'PrintBit lockdown state applied';Passed = ($applied -eq 1);                 Detail = "PrintBitApplied=$applied" }
+
+Write-Host ""
+Write-Host "[PrintBit] Kiosk lockdown verification" -ForegroundColor Cyan
+Write-Host ""
+
+foreach ($check in $checks) {
+  Write-Check -Name $check.Name -Passed ([bool]$check.Passed) -Detail $check.Detail
+}
+
+$failCount = ($checks | Where-Object { -not $_.Passed }).Count
+Write-Host ""
+if ($failCount -eq 0) {
+  Write-Host "[PrintBit] [OK] All lockdown checks passed." -ForegroundColor Green
+  exit 0
+}
+
+Write-Host "[PrintBit] [!!] $failCount check(s) failed." -ForegroundColor Red
+exit 1

--- a/src/config/http.ts
+++ b/src/config/http.ts
@@ -22,9 +22,13 @@ export const CAPTIVE_PORTAL_ENABLED =
 /** Kiosk lockdown controls */
 export const KIOSK_LOCKDOWN_ENABLED =
   process.env.PRINTBIT_KIOSK_LOCKDOWN === 'true';
+const USB_EXPORT_DISABLED_TOKENS = new Set(['false', '0', 'no', '']);
+const usbExportEnv = process.env.PRINTBIT_USB_EXPORT_ENABLED
+  ?.trim()
+  .toLowerCase();
 export const USB_EXPORT_ENABLED =
-  process.env.PRINTBIT_USB_EXPORT_ENABLED !== undefined
-    ? process.env.PRINTBIT_USB_EXPORT_ENABLED !== 'false'
+  usbExportEnv !== undefined
+    ? !USB_EXPORT_DISABLED_TOKENS.has(usbExportEnv)
     : !KIOSK_LOCKDOWN_ENABLED;
 
 /** MyPublicWiFi installation path */

--- a/src/config/http.ts
+++ b/src/config/http.ts
@@ -19,6 +19,14 @@ export const HOTSPOT_PASSWORD =
 export const CAPTIVE_PORTAL_ENABLED =
   process.env.PRINTBIT_CAPTIVE_PORTAL !== 'false';
 
+/** Kiosk lockdown controls */
+export const KIOSK_LOCKDOWN_ENABLED =
+  process.env.PRINTBIT_KIOSK_LOCKDOWN === 'true';
+export const USB_EXPORT_ENABLED =
+  process.env.PRINTBIT_USB_EXPORT_ENABLED !== undefined
+    ? process.env.PRINTBIT_USB_EXPORT_ENABLED !== 'false'
+    : !KIOSK_LOCKDOWN_ENABLED;
+
 /** MyPublicWiFi installation path */
 export const MYPUBLICWIFI_PATH =
   process.env.PRINTBIT_MYPUBLICWIFI_PATH ??

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -385,8 +385,7 @@
           <li>Tap <strong>Get Soft Copy</strong>.</li>
           <li>
             Choose delivery: <strong>Wireless (QR)</strong> to scan a code on
-            your phone, or <strong>USB Flash Drive</strong> to export to a USB
-            stick.
+            your phone.
           </li>
         </ol>
         <p class="guide-card__section">Troubleshooting</p>
@@ -394,8 +393,7 @@
           <li>Scanner unavailable? Check the cable/power and try again.</li>
           <li>QR link expired? Tap <strong>Refresh QR Link</strong>.</li>
           <li>
-            No USB detected? Insert or reinsert the drive and tap
-            <strong>Refresh USB</strong>.
+            For lockdown deployments, USB storage is intentionally blocked.
           </li>
         </ul>
         <button

--- a/src/public/scan/index.html
+++ b/src/public/scan/index.html
@@ -489,7 +489,7 @@
               <p class="delivery-pre__title">Soft copy ready after scan</p>
               <p class="delivery-pre__sub">
                 Scan your document, then tap <em>Get Soft Copy</em> to unlock
-                wireless QR or USB export
+                wireless QR download
               </p>
               <p class="delivery-pre__sub">
                 <strong>Soft copy fee: loading...</strong>
@@ -563,102 +563,6 @@
                   Refresh Link
                 </button>
                 <p id="wirelessStatusText" class="delivery-status"></p>
-              </div>
-
-              <!-- Wired USB card -->
-              <div
-                id="wiredDeliveryCard"
-                class="delivery-card"
-                style="display: none"
-              >
-                <div class="delivery-card__header">
-                  <div class="delivery-card__icon-wrap" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" fill="none">
-                      <rect
-                        x="7"
-                        y="2"
-                        width="10"
-                        height="16"
-                        rx="2.5"
-                        stroke="currentColor"
-                        stroke-width="1.8"
-                        opacity=".85"
-                      />
-                      <path
-                        d="M9.5 6h5M9.5 10h5M9.5 14h3"
-                        stroke="currentColor"
-                        stroke-width="1.8"
-                        stroke-linecap="round"
-                      />
-                      <path
-                        d="M12 18v4"
-                        stroke="currentColor"
-                        stroke-width="1.8"
-                        stroke-linecap="round"
-                        opacity=".5"
-                      />
-                    </svg>
-                  </div>
-                  <div>
-                    <p class="delivery-card__title">USB Export</p>
-                    <p class="delivery-card__sub">Save to a flash drive</p>
-                  </div>
-                </div>
-
-                <div class="drive-row">
-                  <select
-                    id="driveSelect"
-                    class="drive-select"
-                    aria-label="USB drive"
-                  >
-                    <option value="">No USB drive detected</option>
-                  </select>
-                  <button
-                    type="button"
-                    id="refreshDrivesBtn"
-                    class="delivery-btn delivery-btn--icon"
-                  >
-                    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                      <path
-                        d="M2.5 8A5.5 5.5 0 0113 5M13.5 8A5.5 5.5 0 013 11"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                      />
-                      <path
-                        d="M11.5 5V2.5M4.5 11v2.5"
-                        stroke="currentColor"
-                        stroke-width="1.5"
-                        stroke-linecap="round"
-                      />
-                    </svg>
-                  </button>
-                </div>
-
-                <button
-                  type="button"
-                  id="exportUsbBtn"
-                  class="delivery-btn delivery-btn--primary"
-                  disabled
-                >
-                  <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                    <path
-                      d="M8 2v8M5 7l3 3 3-3"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <path
-                      d="M2 12h12"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                  Export to USB
-                </button>
-                <p id="wiredStatusText" class="delivery-status"></p>
               </div>
             </section>
             <!-- /deliveryPanel -->

--- a/src/routes/scan-routes.ts
+++ b/src/routes/scan-routes.ts
@@ -1,7 +1,8 @@
-import type { Express, Request, Response } from 'express';
-import { Server } from 'socket.io';
 import path from 'node:path';
 import fs from 'node:fs';
+import type { Express, Request, Response } from 'express';
+import { Server } from 'socket.io';
+import { USB_EXPORT_ENABLED } from '@/config';
 import { settlementService } from '@/services';
 import { jobStore } from '@/services/job-store';
 import { db } from '@/services/db';
@@ -58,6 +59,14 @@ function toScanSource(source: ScannerPageSource): 'flatbed' | 'adf' {
 
 function toColorMode(color: ScannerPageColor): 'colored' | 'grayscale' {
   return color === 'grayscale' ? 'grayscale' : 'colored';
+}
+
+function sendUsbExportDisabled(res: Response): Response {
+  return res.status(423).json({
+    code: 'USB_EXPORT_DISABLED',
+    error:
+      'USB export is disabled in kiosk lockdown mode. Use wireless QR download instead.',
+  });
 }
 
 function markSoftCopyPaid(filename: string): void {
@@ -325,6 +334,10 @@ export function registerScanRoutes(
 
   // ── GET /api/scanner/wired/drives — Detect removable USB drives ─────
   app.get('/api/scanner/wired/drives', async (_req: Request, res: Response) => {
+    if (!USB_EXPORT_ENABLED) {
+      return sendUsbExportDisabled(res);
+    }
+
     try {
       const drives = await listRemovableDrives();
       res.json({ drives });
@@ -337,6 +350,10 @@ export function registerScanRoutes(
 
   // ── POST /api/scanner/wired/export — Copy scan to USB drive ─────────
   app.post('/api/scanner/wired/export', async (req: Request, res: Response) => {
+    if (!USB_EXPORT_ENABLED) {
+      return sendUsbExportDisabled(res);
+    }
+
     const safeFilename = toSafeScanFilename(req.body?.filename);
     const drive = typeof req.body?.drive === 'string' ? req.body.drive : '';
 


### PR DESCRIPTION
# #38 Implemented Windows Kiosk Lockdown

This pull request introduces comprehensive support for Windows kiosk lockdown deployment for the PrintBit app, including new scripts and documentation for applying, verifying, and reverting lockdown policies. It also ensures that USB export is disabled in kiosk lockdown mode, with consistent environment variable handling and clear user/operator messaging across documentation and startup scripts.

**Windows Kiosk Lockdown Support and USB Export Gating:**

*Major features and changes:*

**1. Kiosk Lockdown Scripts and Automation**
- Added new PowerShell scripts: `apply-kiosk-lockdown.ps1` (applies registry-based lockdown policies, disables USB mass storage, restricts shortcuts, etc.), `verify-kiosk-lockdown.ps1` (not shown here, but referenced), and `revert-kiosk-lockdown.ps1` (reverts lockdown changes for maintenance). These scripts are integrated into `package.json` as `lockdown:apply`, `lockdown:verify`, and `lockdown:revert` commands. [[1]](diffhunk://#diff-b86a5468f187d958f62c2b0d0aa5bc02e4862a9c9077ca86b59fbfadcdc4c086R1-R105) [[2]](diffhunk://#diff-5f05cd6e977f81208caeaff0bf6f020cd0b8e3ad8591d0854b55c8be87001d75R1-R64) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R14)

**2. Documentation and Operator Guidance**
- Added a detailed `WINDOWS_KIOSK_LOCKDOWN_SETUP.md` guide covering environment setup, lockdown policy, startup automation, and validation for Windows tablets in kiosk mode.
- Updated `README.md`, `OPERATIONS.md`, and `API_DOCUMENTATION.md` to clarify that USB export is intentionally disabled during kiosk lockdown, and to document the new error response for USB endpoints when locked down. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R62) [[2]](diffhunk://#diff-fb2c4fc67269b004dff6972148a4867aa7fc3f288841ec86c0bea3cf04a83fa0L62-R62) [[3]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39L248-R271)

**3. Environment Variable Handling and Startup Scripts**
- Startup scripts (`run.bat`, `start-kiosk.bat`, `start-kiosk.ps1`) now explicitly set and propagate `PRINTBIT_KIOSK_LOCKDOWN` and `PRINTBIT_USB_EXPORT_ENABLED` environment variables, ensuring consistent app behavior and correct gating of USB export features. Startup output now displays the lockdown status and USB export flag. [[1]](diffhunk://#diff-e967a38c0165058adc56c9c7505636f83704ae4362e0708c05063e11d91f468eR7-R8) [[2]](diffhunk://#diff-f16570543c52b09105309b341709b4287357189d9d7c46753198e26e5726f0d5R23-R27) [[3]](diffhunk://#diff-f16570543c52b09105309b341709b4287357189d9d7c46753198e26e5726f0d5L55-R60) [[4]](diffhunk://#diff-4cb3c4e74f5686199c5c52d0f22517e447b59bc259acd60b543de11aca3efd7cR31-R32) [[5]](diffhunk://#diff-4cb3c4e74f5686199c5c52d0f22517e447b59bc259acd60b543de11aca3efd7cR41-R42) [[6]](diffhunk://#diff-4cb3c4e74f5686199c5c52d0f22517e447b59bc259acd60b543de11aca3efd7cL63-R67)

**4. Startup Automation Improvements**
- Enhanced scheduled task installation in `install-startup.ps1` (minor output tweaks and argument handling), and added a new `install-startup` command to `package.json` for easier setup. [[1]](diffhunk://#diff-9cc9aa8e6463899338fcf6626df87cd1c1ddad8082519113ec39c2c7f376d389L35-R35) [[2]](diffhunk://#diff-9cc9aa8e6463899338fcf6626df87cd1c1ddad8082519113ec39c2c7f376d389L53-R53) [[3]](diffhunk://#diff-9cc9aa8e6463899338fcf6626df87cd1c1ddad8082519113ec39c2c7f376d389L80-R80) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R14)

**5. API and User Experience Consistency**
- The API now returns a clear `423` error with a specific code and message when USB export is blocked by lockdown, and all relevant documentation reflects this behavior. [[1]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39L248-R271) [[2]](diffhunk://#diff-fb2c4fc67269b004dff6972148a4867aa7fc3f288841ec86c0bea3cf04a83fa0L62-R62) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R62)

These changes provide a robust foundation for secure, maintainable Windows kiosk deployments and ensure that USB export is reliably disabled when required by policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kiosk lockdown mode disables USB mass‑storage export; USB export endpoints now return 423/USB_EXPORT_DISABLED
  * New commands/scripts to apply, verify, and revert kiosk lockdown and to install startup behavior; startup exposes lockdown-related env flags

* **Documentation**
  * Added a full Windows kiosk lockdown setup guide
  * Updated API, operations, README, and in-app scan instructions to reflect USB export removal and wireless‑only delivery
<!-- end of auto-generated comment: release notes by coderabbit.ai -->