### PR TITLE
feat: integrate refreshPrinterTelemetry for improved printer status detection

### DIFF
--- a/src/modules/copy/copy.service.ts
+++ b/src/modules/copy/copy.service.ts
@@ -13,6 +13,7 @@ import { adminService } from '@/services/admin';
 import {
   evaluateInkPreflight,
   getPrinterTelemetry,
+  refreshPrinterTelemetry,
   settlementService,
   watchJobForMalfunction,
 } from '@/services';
@@ -344,7 +345,7 @@ export class CopyService {
     void (async () => {
       jobStore.updateJobState(jobId, 'running');
       try {
-        const telemetry = getPrinterTelemetry();
+        const telemetry = await refreshPrinterTelemetry();
         if (!telemetry.connected || BLOCKED_STATUSES.has(telemetry.status)) {
           void adminService.appendAdminLog(
             'copy_preflight_failed',

--- a/src/modules/financial/financial.service.ts
+++ b/src/modules/financial/financial.service.ts
@@ -9,7 +9,11 @@ import {
   storeIdempotencyKey,
   releaseIdempotencyKey,
 } from '@/services/db';
-import { evaluateInkPreflight, getPrinterTelemetry } from '@/services';
+import {
+  evaluateInkPreflight,
+  getPrinterTelemetry,
+  refreshPrinterTelemetry,
+} from '@/services';
 import { adminService } from '@/services/admin';
 import { settlementService } from '@/services/settlement';
 import { printFile, type PrintJobOptions } from '@/services/printer';
@@ -461,6 +465,52 @@ export class FinancialService {
       paperSize: 'A4',
     };
 
+    const legacyTelemetry = await refreshPrinterTelemetry();
+    if (
+      !legacyTelemetry.connected ||
+      BLOCKED_STATUSES.has(legacyTelemetry.status)
+    ) {
+      void adminService.appendAdminLog(
+        'print_preflight_failed',
+        'Legacy print rejected: printer not ready.',
+        {
+          filename,
+          printerStatus: legacyTelemetry.status,
+          printerConnected: legacyTelemetry.connected,
+        },
+      );
+      return res.status(409).json({
+        error: `Printer is not ready: ${legacyTelemetry.status}. Please notify the operator.`,
+        printerStatus: legacyTelemetry.status,
+      });
+    }
+
+    const legacyInkPreflight = evaluateInkPreflight(legacyTelemetry);
+    if (legacyInkPreflight.blocked) {
+      void adminService.appendAdminLog(
+        'print_preflight_failed_ink',
+        'Legacy print rejected: ink preflight policy blocked the job.',
+        {
+          filename,
+          printerStatus: legacyTelemetry.status,
+          inkCode: legacyInkPreflight.code,
+          inkReason:
+            legacyInkPreflight.reason ?? 'Unknown ink policy reason',
+          telemetryAvailable: legacyInkPreflight.telemetryAvailable,
+          inkDetectionMethod: legacyTelemetry.inkDetectionMethod,
+        },
+      );
+      return res.status(409).json({
+        error:
+          legacyInkPreflight.reason ??
+          'Printer ink state is not ready for printing.',
+        printerStatus: legacyTelemetry.status,
+        inkStatus: legacyInkPreflight.code,
+        inkReason: legacyInkPreflight.reason,
+        telemetryAvailable: legacyInkPreflight.telemetryAvailable,
+      });
+    }
+
     try {
       await printFile(filename, defaultOptions);
     } catch (err) {
@@ -819,7 +869,8 @@ export class FinancialService {
       return;
     }
 
-    const telemetry = getPrinterTelemetry();
+    const telemetry =
+      mode === 'print' ? await refreshPrinterTelemetry() : getPrinterTelemetry();
     let jobDispatchedAt: string | null = null;
 
     if (mode === 'print' && serverFilename && printOptions) {

--- a/src/services/printer-status.ts
+++ b/src/services/printer-status.ts
@@ -77,6 +77,8 @@ interface PnpPrinterDeviceInfo {
   FriendlyName: string | null;
   InstanceId: string | null;
   Status: string | null;
+  Present: boolean | null;
+  Problem: number | null;
   SerialNumber: string | null;
 }
 
@@ -134,6 +136,40 @@ function humanStatusFromFlags(
   if (flags.includes('Paused')) return 'Paused';
   if (flags.length === 0 || printerStatusCode === 3) return 'Idle';
   return flags[0] ?? 'Unknown';
+}
+
+function applyConnectionSignals(input: {
+  status: string;
+  statusFlags: string[];
+  connectionType: PrinterTelemetry['connectionType'];
+  workOffline: boolean | null | undefined;
+  pnpDevice?: PnpPrinterDeviceInfo | null;
+}): { connected: boolean; status: string; statusFlags: string[] } {
+  const statusFlags = [...input.statusFlags];
+  let connected = true;
+
+  if (input.workOffline === true) {
+    connected = false;
+    if (!statusFlags.includes('Offline')) statusFlags.push('Offline');
+  }
+
+  if (input.connectionType === 'usb' && input.pnpDevice) {
+    const notPresent = input.pnpDevice.Present === false;
+    const deviceNotConnected = input.pnpDevice.Problem === 45;
+    if (notPresent || deviceNotConnected) {
+      connected = false;
+      if (!statusFlags.includes('Offline')) statusFlags.push('Offline');
+      if (!statusFlags.includes('Device Not Connected')) {
+        statusFlags.push('Device Not Connected');
+      }
+    }
+  }
+
+  return {
+    connected,
+    status: connected ? input.status : 'Offline',
+    statusFlags,
+  };
 }
 
 // ── Port → connection type ───────────────────────────────────────
@@ -470,7 +506,7 @@ export async function queryLivePrinterStatus(): Promise<{
     const json = await runPowerShell(
       `Get-CimInstance -ClassName Win32_Printer ` +
         filter +
-        `| Select-Object PrinterStatus, PrinterState ` +
+        `| Select-Object Name, PortName, PrinterStatus, PrinterState, WorkOffline ` +
         `| ConvertTo-Json -Depth 2`,
       5_000,
     );
@@ -486,12 +522,22 @@ export async function queryLivePrinterStatus(): Promise<{
     }
 
     const raw = JSON.parse(json) as {
+      Name: string;
+      PortName: string;
       PrinterStatus: number;
       PrinterState: number;
+      WorkOffline?: boolean | null;
     };
     const statusFlags = parsePrinterStateFlags(raw.PrinterState);
     const status = humanStatusFromFlags(statusFlags, raw.PrinterStatus);
-    return { connected: true, status, statusFlags };
+    const connectionType = detectConnectionType(raw.PortName ?? null);
+    const normalized = applyConnectionSignals({
+      status,
+      statusFlags,
+      connectionType,
+      workOffline: raw.WorkOffline,
+    });
+    return normalized;
   } catch {
     return { connected: false, status: 'Error', statusFlags: [] };
   }
@@ -518,13 +564,14 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
     Default?: boolean;
     PrinterStatus: number;
     PrinterState: number;
+    WorkOffline?: boolean | null;
   } | null = null;
 
   try {
     const json = await runPowerShell(
       `Get-CimInstance -ClassName Win32_Printer ` +
         queryFilter +
-        `| Select-Object Name, DriverName, PortName, Default, PrinterStatus, PrinterState ` +
+        `| Select-Object Name, DriverName, PortName, Default, PrinterStatus, PrinterState, WorkOffline ` +
         `| ConvertTo-Json -Depth 2`,
     );
 
@@ -560,6 +607,18 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
   const statusFlags = parsePrinterStateFlags(printerInfo.PrinterState);
   const status = humanStatusFromFlags(statusFlags, printerInfo.PrinterStatus);
   const connectionType = detectConnectionType(printerInfo.PortName);
+  let matchedPnpDevice: PnpPrinterDeviceInfo | null = null;
+  if (connectionType === 'usb') {
+    const pnpDevices = await listPnpPrinterDevices();
+    matchedPnpDevice = matchPnpDeviceToPrinter(printerInfo, pnpDevices);
+  }
+  const connectivity = applyConnectionSignals({
+    status,
+    statusFlags,
+    connectionType,
+    workOffline: printerInfo.WorkOffline,
+    pnpDevice: matchedPnpDevice,
+  });
 
   // 2) Attempt ink detection with a prioritized strategy chain
   const { ink, method } = await detectInkLevels(
@@ -572,13 +631,13 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
   );
 
   return {
-    connected: true,
+    connected: connectivity.connected,
     name: printerInfo.Name,
     driverName: printerInfo.DriverName,
     portName: printerInfo.PortName,
     connectionType,
-    status,
-    statusFlags,
+    status: connectivity.status,
+    statusFlags: connectivity.statusFlags,
     ink,
     inkDetectionMethod: method,
     targetPrinterName,
@@ -1314,7 +1373,7 @@ async function listPnpPrinterDevices(): Promise<PnpPrinterDeviceInfo[]> {
     const json = await runPowerShell(
       `$devices = Get-PnpDevice -Class Printer -ErrorAction SilentlyContinue | ForEach-Object { ` +
         `$serial = ($_ | Get-PnpDeviceProperty -KeyName 'DEVPKEY_Device_SerialNumber' -ErrorAction SilentlyContinue).Data; ` +
-        `[PSCustomObject]@{ FriendlyName = $_.FriendlyName; InstanceId = $_.InstanceId; Status = $_.Status; SerialNumber = if ($null -eq $serial -or $serial -eq '') { $null } else { [string]$serial } } ` +
+        `[PSCustomObject]@{ FriendlyName = $_.FriendlyName; InstanceId = $_.InstanceId; Status = $_.Status; Present = $_.Present; Problem = $_.Problem; SerialNumber = if ($null -eq $serial -or $serial -eq '') { $null } else { [string]$serial } } ` +
       `}; ` +
       `if ($devices) { $devices | ConvertTo-Json -Depth 4 } else { '[]' }`,
       10_000,

--- a/src/services/printer-status.ts
+++ b/src/services/printer-status.ts
@@ -145,8 +145,13 @@ function applyConnectionSignals(input: {
   workOffline: boolean | null | undefined;
   pnpDevice?: PnpPrinterDeviceInfo | null;
 }): { connected: boolean; status: string; statusFlags: string[] } {
-  const statusFlags = [...input.statusFlags];
+  const statusFlags = Array.from(new Set(input.statusFlags));
   let connected = true;
+
+  if (input.status === 'Offline' || statusFlags.includes('Offline')) {
+    connected = false;
+    if (!statusFlags.includes('Offline')) statusFlags.push('Offline');
+  }
 
   if (input.workOffline === true) {
     connected = false;
@@ -278,6 +283,7 @@ let cached: PrinterTelemetry = {
   lastError: null,
 };
 let refreshing = false;
+let pendingRefresh: Promise<PrinterTelemetry> | null = null;
 
 function normalizeTargetPrinterName(
   value: string | null | undefined,
@@ -412,63 +418,16 @@ function updatePrinterWatchdogState(telemetry: PrinterTelemetry): void {
 }
 
 async function refresh(): Promise<void> {
-  if (refreshing) return;
-  refreshing = true;
-  try {
-    cached = normalizeTelemetryAvailability(await queryPrinterTelemetry());
-    persistInkHistoryEntry(cached);
-    await db.write();
-    updatePrinterWatchdogState(cached);
-  } catch (err: unknown) {
-    cached = {
-      connected: false,
-      name: null,
-      driverName: null,
-      portName: null,
-      connectionType: 'unknown',
-      status: 'Error',
-      statusFlags: [],
-      ink: [],
-      inkDetectionMethod: 'none',
-      targetPrinterName: null,
-      targetIsDefault: false,
-      inkTelemetryAvailable: false,
-      inkTelemetryReason: 'Telemetry refresh failed',
-      lastCheckedAt: new Date().toISOString(),
-      lastError: err instanceof Error ? err.message : String(err),
-    };
-    markWatchdogHeartbeat('printer', {
-      connected: false,
-      status: cached.status,
-      telemetryLastCheckedAt: cached.lastCheckedAt,
-    });
-    setWatchdogComponentState(
-      'printer',
-      'degraded',
-      `Printer telemetry refresh failed: ${cached.lastError}`,
-      {
-        connected: false,
-        status: 'Error',
-        telemetryLastCheckedAt: cached.lastCheckedAt,
-        lastError: cached.lastError,
-      },
-    );
-  } finally {
-    refreshing = false;
+  if (pendingRefresh) {
+    await pendingRefresh;
+    return;
   }
 
-  // Notify all registered subscribers with the latest snapshot.
-  // Each callback is wrapped individually so one failing subscriber cannot
-  // prevent the others from receiving the update.
-  for (const cb of refreshCallbacks) {
-    try {
-      cb(cached);
-    } catch (err) {
-      console.warn(
-        '[PRINTER-STATUS] refresh callback threw:',
-        err instanceof Error ? err.message : err,
-      );
-    }
+  pendingRefresh = runRefreshCycle();
+  try {
+    await pendingRefresh;
+  } finally {
+    pendingRefresh = null;
   }
 }
 
@@ -492,6 +451,7 @@ export async function queryLivePrinterStatus(): Promise<{
   connected: boolean;
   status: string;
   statusFlags: string[];
+  pnpDevice: PnpPrinterDeviceInfo | null;
 }> {
   try {
     const settings = getInkMonitoringSettings();
@@ -506,7 +466,7 @@ export async function queryLivePrinterStatus(): Promise<{
     const json = await runPowerShell(
       `Get-CimInstance -ClassName Win32_Printer ` +
         filter +
-        `| Select-Object Name, PortName, PrinterStatus, PrinterState, WorkOffline ` +
+        `| Select-Object Name, DriverName, PortName, PrinterStatus, PrinterState, WorkOffline ` +
         `| ConvertTo-Json -Depth 2`,
       5_000,
     );
@@ -518,11 +478,13 @@ export async function queryLivePrinterStatus(): Promise<{
           ? 'Configured printer not found'
           : 'No default printer',
         statusFlags: [],
+        pnpDevice: null,
       };
     }
 
     const raw = JSON.parse(json) as {
       Name: string;
+      DriverName: string;
       PortName: string;
       PrinterStatus: number;
       PrinterState: number;
@@ -531,15 +493,35 @@ export async function queryLivePrinterStatus(): Promise<{
     const statusFlags = parsePrinterStateFlags(raw.PrinterState);
     const status = humanStatusFromFlags(statusFlags, raw.PrinterStatus);
     const connectionType = detectConnectionType(raw.PortName ?? null);
+    let matchedPnpDevice: PnpPrinterDeviceInfo | null = null;
+    if (connectionType === 'usb') {
+      const pnpDevices = await listPnpPrinterDevices();
+      matchedPnpDevice = matchPnpDeviceToPrinter(
+        {
+          Name: raw.Name,
+          DriverName: raw.DriverName,
+          PortName: raw.PortName,
+          Default: true,
+          PrinterStatus: raw.PrinterStatus,
+          PrinterState: raw.PrinterState,
+        },
+        pnpDevices,
+      );
+    }
+    const printerRecord = { ...raw, pnpDevice: matchedPnpDevice };
     const normalized = applyConnectionSignals({
       status,
       statusFlags,
       connectionType,
-      workOffline: raw.WorkOffline,
+      workOffline: printerRecord.WorkOffline,
+      pnpDevice: printerRecord.pnpDevice,
     });
-    return normalized;
+    return {
+      ...normalized,
+      pnpDevice: printerRecord.pnpDevice,
+    };
   } catch {
-    return { connected: false, status: 'Error', statusFlags: [] };
+    return { connected: false, status: 'Error', statusFlags: [], pnpDevice: null };
   }
 }
 
@@ -565,6 +547,7 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
     PrinterStatus: number;
     PrinterState: number;
     WorkOffline?: boolean | null;
+    pnpDevice?: PnpPrinterDeviceInfo | null;
   } | null = null;
 
   try {
@@ -612,23 +595,32 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
     const pnpDevices = await listPnpPrinterDevices();
     matchedPnpDevice = matchPnpDeviceToPrinter(printerInfo, pnpDevices);
   }
+  printerInfo.pnpDevice = matchedPnpDevice;
   const connectivity = applyConnectionSignals({
     status,
     statusFlags,
     connectionType,
     workOffline: printerInfo.WorkOffline,
-    pnpDevice: matchedPnpDevice,
+    pnpDevice: printerInfo.pnpDevice,
   });
 
-  // 2) Attempt ink detection with a prioritized strategy chain
-  const { ink, method } = await detectInkLevels(
-    printerInfo.Name,
-    printerInfo.DriverName,
-    printerInfo.PortName,
-    printerInfo.PrinterState,
-    printerInfo.PrinterStatus,
-    connectionType,
-  );
+  // 2) Attempt ink detection with a prioritized strategy chain only when
+  // connectivity indicates the printer is actually reachable.
+  const isBlocked =
+    !connectivity.connected || BLOCKED_STATUSES.has(connectivity.status);
+  const { ink, method } = isBlocked
+    ? {
+        ink: [{ name: 'Ink / Toner', level: null, status: 'unknown' }] as InkLevel[],
+        method: 'none' as const,
+      }
+    : await detectInkLevels(
+        printerInfo.Name,
+        printerInfo.DriverName,
+        printerInfo.PortName,
+        printerInfo.PrinterState,
+        printerInfo.PrinterStatus,
+        connectionType,
+      );
 
   return {
     connected: connectivity.connected,
@@ -645,6 +637,66 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
     lastCheckedAt,
     lastError: null,
   };
+}
+
+async function runRefreshCycle(): Promise<PrinterTelemetry> {
+  if (refreshing) return cached;
+  refreshing = true;
+  try {
+    cached = normalizeTelemetryAvailability(await queryPrinterTelemetry());
+    persistInkHistoryEntry(cached);
+    await db.write();
+    updatePrinterWatchdogState(cached);
+  } catch (err: unknown) {
+    cached = {
+      connected: false,
+      name: null,
+      driverName: null,
+      portName: null,
+      connectionType: 'unknown',
+      status: 'Error',
+      statusFlags: [],
+      ink: [],
+      inkDetectionMethod: 'none',
+      targetPrinterName: null,
+      targetIsDefault: false,
+      inkTelemetryAvailable: false,
+      inkTelemetryReason: 'Telemetry refresh failed',
+      lastCheckedAt: new Date().toISOString(),
+      lastError: err instanceof Error ? err.message : String(err),
+    };
+    markWatchdogHeartbeat('printer', {
+      connected: false,
+      status: cached.status,
+      telemetryLastCheckedAt: cached.lastCheckedAt,
+    });
+    setWatchdogComponentState(
+      'printer',
+      'degraded',
+      `Printer telemetry refresh failed: ${cached.lastError}`,
+      {
+        connected: false,
+        status: 'Error',
+        telemetryLastCheckedAt: cached.lastCheckedAt,
+        lastError: cached.lastError,
+      },
+    );
+  } finally {
+    refreshing = false;
+  }
+
+  for (const cb of refreshCallbacks) {
+    try {
+      cb(cached);
+    } catch (err) {
+      console.warn(
+        '[PRINTER-STATUS] refresh callback threw:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  return cached;
 }
 
 function noDefaultPrinter(
@@ -1138,77 +1190,23 @@ function inkStatusFromLevel(level: number | null): InkLevel['status'] {
  * the admin panel reflects the new hardware state without waiting for the next
  * automatic refresh cycle.
  *
- * Safe to call concurrently — if a background refresh is already running it is
- * allowed to finish first (we await it via the shared `refreshing` guard),
- * then we run a fresh query on top so the caller always gets a post-action
- * snapshot, not a stale one.
+ * Safe to call concurrently — callers are coalesced onto one shared in-flight
+ * refresh Promise so only one telemetry query + callback dispatch runs at once.
  *
  * @returns The freshly-queried PrinterTelemetry object (also updates the cache
  *          so subsequent `getPrinterTelemetry()` calls see the same value).
  */
 export async function refreshPrinterTelemetry(): Promise<PrinterTelemetry> {
-  // If a refresh is already in flight, wait for it to settle before we
-  // fire our own so we don't race against it.
-  while (refreshing) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  if (pendingRefresh) {
+    return pendingRefresh;
   }
+  pendingRefresh = runRefreshCycle();
 
-  refreshing = true;
   try {
-    cached = normalizeTelemetryAvailability(await queryPrinterTelemetry());
-    persistInkHistoryEntry(cached);
-    await db.write();
-    updatePrinterWatchdogState(cached);
-  } catch (err: unknown) {
-    cached = {
-      connected: false,
-      name: null,
-      driverName: null,
-      portName: null,
-      connectionType: 'unknown',
-      status: 'Error',
-      statusFlags: [],
-      ink: [],
-      inkDetectionMethod: 'none',
-      targetPrinterName: null,
-      targetIsDefault: false,
-      inkTelemetryAvailable: false,
-      inkTelemetryReason: 'Telemetry refresh failed',
-      lastCheckedAt: new Date().toISOString(),
-      lastError: err instanceof Error ? err.message : String(err),
-    };
-    markWatchdogHeartbeat('printer', {
-      connected: false,
-      status: cached.status,
-      telemetryLastCheckedAt: cached.lastCheckedAt,
-    });
-    setWatchdogComponentState(
-      'printer',
-      'degraded',
-      `Printer telemetry refresh failed: ${cached.lastError}`,
-      {
-        connected: false,
-        status: cached.status,
-        telemetryLastCheckedAt: cached.lastCheckedAt,
-        lastError: cached.lastError,
-      },
-    );
+    return await pendingRefresh;
   } finally {
-    refreshing = false;
+    pendingRefresh = null;
   }
-
-  for (const cb of refreshCallbacks) {
-    try {
-      cb(cached);
-    } catch (error) {
-      console.warn(
-        '[PRINTER-STATUS] refresh callback threw:',
-        error instanceof Error ? error.message : error,
-      );
-    }
-  }
-
-  return cached;
 }
 
 export async function listInstalledPrinters(): Promise<InstalledPrinterInfo[]> {

--- a/src/services/printer-status.ts
+++ b/src/services/printer-status.ts
@@ -495,7 +495,7 @@ export async function queryLivePrinterStatus(): Promise<{
     const connectionType = detectConnectionType(raw.PortName ?? null);
     let matchedPnpDevice: PnpPrinterDeviceInfo | null = null;
     if (connectionType === 'usb') {
-      const pnpDevices = await listPnpPrinterDevices();
+      const pnpDevices = await listPnpPrinterDevices(1_000);
       matchedPnpDevice = matchPnpDeviceToPrinter(
         {
           Name: raw.Name,
@@ -521,7 +521,12 @@ export async function queryLivePrinterStatus(): Promise<{
       pnpDevice: printerRecord.pnpDevice,
     };
   } catch {
-    return { connected: false, status: 'Error', statusFlags: [], pnpDevice: null };
+    return {
+      connected: false,
+      status: 'Error',
+      statusFlags: [],
+      pnpDevice: null,
+    };
   }
 }
 
@@ -610,7 +615,9 @@ async function queryPrinterTelemetry(): Promise<PrinterTelemetry> {
     !connectivity.connected || BLOCKED_STATUSES.has(connectivity.status);
   const { ink, method } = isBlocked
     ? {
-        ink: [{ name: 'Ink / Toner', level: null, status: 'unknown' }] as InkLevel[],
+        ink: [
+          { name: 'Ink / Toner', level: null, status: 'unknown' },
+        ] as InkLevel[],
         method: 'none' as const,
       }
     : await detectInkLevels(
@@ -643,10 +650,27 @@ async function runRefreshCycle(): Promise<PrinterTelemetry> {
   if (refreshing) return cached;
   refreshing = true;
   try {
-    cached = normalizeTelemetryAvailability(await queryPrinterTelemetry());
-    persistInkHistoryEntry(cached);
-    await db.write();
-    updatePrinterWatchdogState(cached);
+    const next = normalizeTelemetryAvailability(await queryPrinterTelemetry());
+    cached = next;
+
+    try {
+      persistInkHistoryEntry(next);
+      await db.write();
+    } catch (err) {
+      console.warn(
+        '[PRINTER-STATUS] Failed to persist telemetry history:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    try {
+      updatePrinterWatchdogState(next);
+    } catch (err) {
+      console.warn(
+        '[PRINTER-STATUS] Failed to update printer watchdog:',
+        err instanceof Error ? err.message : err,
+      );
+    }
   } catch (err: unknown) {
     cached = {
       connected: false,
@@ -1319,10 +1343,7 @@ export async function runInkTelemetryDiagnostics(): Promise<{
 
 function normalizeComparableName(value: string | null | undefined): string {
   if (!value) return '';
-  return value
-    .replace(/\s+/g, ' ')
-    .trim()
-    .toLowerCase();
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
 }
 
 function extractPortTokenFromInstanceId(
@@ -1358,7 +1379,7 @@ function matchPnpDeviceToPrinter(
     const friendly = normalizeComparableName(device.FriendlyName);
     if (!friendly || !normalizedDriver) return false;
     return (
-      (friendly.includes(normalizedDriver) || normalizedDriver.includes(friendly))
+      friendly.includes(normalizedDriver) || normalizedDriver.includes(friendly)
     );
   });
   if (byDriverName) return byDriverName;
@@ -1366,15 +1387,17 @@ function matchPnpDeviceToPrinter(
   return null;
 }
 
-async function listPnpPrinterDevices(): Promise<PnpPrinterDeviceInfo[]> {
+async function listPnpPrinterDevices(
+  timeoutMs = 10_000,
+): Promise<PnpPrinterDeviceInfo[]> {
   try {
     const json = await runPowerShell(
       `$devices = Get-PnpDevice -Class Printer -ErrorAction SilentlyContinue | ForEach-Object { ` +
         `$serial = ($_ | Get-PnpDeviceProperty -KeyName 'DEVPKEY_Device_SerialNumber' -ErrorAction SilentlyContinue).Data; ` +
         `[PSCustomObject]@{ FriendlyName = $_.FriendlyName; InstanceId = $_.InstanceId; Status = $_.Status; Present = $_.Present; Problem = $_.Problem; SerialNumber = if ($null -eq $serial -or $serial -eq '') { $null } else { [string]$serial } } ` +
-      `}; ` +
-      `if ($devices) { $devices | ConvertTo-Json -Depth 4 } else { '[]' }`,
-      10_000,
+        `}; ` +
+        `if ($devices) { $devices | ConvertTo-Json -Depth 4 } else { '[]' }`,
+      timeoutMs,
     );
     if (!json || json === 'null') return [];
     const parsed = JSON.parse(json) as
@@ -1384,7 +1407,8 @@ async function listPnpPrinterDevices(): Promise<PnpPrinterDeviceInfo[]> {
     return rows.filter(
       (row) =>
         row &&
-        (typeof row.InstanceId === 'string' || typeof row.FriendlyName === 'string'),
+        (typeof row.InstanceId === 'string' ||
+          typeof row.FriendlyName === 'string'),
     );
   } catch {
     return [];


### PR DESCRIPTION
# Refresh Printer Telemetry for Printer Status Detection

This pull request enhances printer connectivity detection and error handling in both the copy and financial modules, ensuring more accurate printer status checks before job execution. The main improvements involve using a new `refreshPrinterTelemetry` function for up-to-date printer status, more robust preflight checks, and expanded device information to better identify offline or problematic printers.

**Printer connectivity and status improvements:**

* Introduced the `refreshPrinterTelemetry` function to obtain real-time printer status, replacing or supplementing previous usage of `getPrinterTelemetry` in both `copy.service.ts` and `financial.service.ts`. This ensures that job preflight checks use the most current printer information. 
* Enhanced preflight checks in `FinancialService` to log and block print jobs if the printer is not ready or if ink policies are violated, providing detailed error responses and admin logs.

**Device status detection and telemetry:**

* Expanded the `PnpPrinterDeviceInfo` interface and PowerShell queries to include `Present` and `Problem` fields, enabling detection of USB device presence and connection issues. 
* Added the `applyConnectionSignals` function in `printer-status.ts` to centralize logic for determining printer connectivity based on new device fields, connection type, and offline status. This logic is now used in both live and telemetry queries. 
* Updated PowerShell queries and parsing in `queryLivePrinterStatus` and `queryPrinterTelemetry` to include and handle the new device fields and connection logic. 

These changes collectively make printer readiness checks more reliable and informative, reducing the risk of dispatching jobs to unavailable or malfunctioning devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection/reporting of offline and disconnected USB printers.
  * Prevented submitting print/copy jobs when connectivity or ink policy blocks them; blocked requests now return proper rejection and admin logs.

* **Improvements**
  * More reliable, coalesced telemetry refreshes to avoid redundant checks and speed up preflight validation.
  * When printer is offline or blocked, ink status is reported as unavailable to avoid false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->