### PR TITLE
feat: add detectedColorMode to PrintConfig and ConfirmConfig for improved color handling

### DIFF
--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -52,6 +52,7 @@ interface PrintConfig {
   filename: string | null;
   copyPreviewPath?: string | null;
   copyPreviewReleaseToken?: string | null;
+  detectedColorMode?: ColorMode | null;
   colorMode: ColorMode;
   duplex: boolean;
   copies: number;
@@ -721,6 +722,7 @@ if (mode === 'copy' && continueBtn) {
 }
 
 let currentPrintQuote: PrintQuote | null = null;
+let detectedColorMode: ColorMode | null = null;
 let quoteError: string | null = null;
 let quoteLoading = false;
 let quoteRequestVersion = 0;
@@ -1281,6 +1283,7 @@ async function applyColorAnalysis(
   filename?: string | null,
 ): Promise<void> {
   resetColorLock();
+  detectedColorMode = null;
 
   let url = `/api/wireless/sessions/${encodeURIComponent(sessionId)}/color-analysis`;
   if (filename) url += `?filename=${encodeURIComponent(filename)}`;
@@ -1295,6 +1298,7 @@ async function applyColorAnalysis(
     if (!resp.ok) return;
 
     const { isGrayscale } = (await resp.json()) as { isGrayscale: boolean };
+    detectedColorMode = isGrayscale ? 'grayscale' : 'colored';
     if (!isGrayscale) return;
 
     const grayRadio = document.querySelector<HTMLInputElement>(
@@ -1305,17 +1309,7 @@ async function applyColorAnalysis(
       grayRadio.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
-    // 2. Disable both color mode cards
-    document
-      .querySelectorAll<HTMLInputElement>('input[name="colorMode"]')
-      .forEach((radio) => {
-        radio.disabled = true;
-        radio
-          .closest<HTMLElement>('.option-card')
-          ?.setAttribute('data-locked', 'true');
-      });
-
-    // 3. Show explanatory notice
+    // Show advisory notice while keeping color controls user-editable.
     const colorGroup = document.querySelector<HTMLElement>(
       '.option-group:has(input[name="colorMode"])',
     );
@@ -1323,10 +1317,11 @@ async function applyColorAnalysis(
       const notice = document.createElement('p');
       notice.className = 'color-lock-notice';
       notice.textContent =
-        'Color printing is unavailable — this document contains only black & white content.';
+        'Auto-detected grayscale. Switch to Colored if your file has color.';
       colorGroup.appendChild(notice);
     }
   } catch (error) {
+    detectedColorMode = null;
     previewLog('applyColorAnalysis() failed', error);
     // Detection failed - leave UI unlocked
   }
@@ -1355,6 +1350,7 @@ continueBtn?.addEventListener('click', () => {
     filename: selectedFile,
     copyPreviewPath: mode === 'copy' ? copyPreviewPath : null,
     copyPreviewReleaseToken: mode === 'copy' ? copyPreviewReleaseToken : null,
+    detectedColorMode: mode === 'print' ? detectedColorMode : null,
     colorMode: cfg.colorMode,
     duplex: false,
     copies: getCopies(),

--- a/src/public/confirm/app.ts
+++ b/src/public/confirm/app.ts
@@ -64,6 +64,7 @@ type ConfirmConfig = {
   scanReleaseToken?: string | null;
   copyPreviewPath?: string | null;
   copyPreviewReleaseToken?: string | null;
+  detectedColorMode?: 'colored' | 'grayscale' | null;
   colorMode: 'colored' | 'grayscale';
   duplex?: boolean;
   copies: number;
@@ -158,6 +159,12 @@ const config = JSON.parse(rawConfig ?? '{}') as ConfirmConfig;
 config.duplex = config.duplex === true;
 if (typeof config.documentId !== 'string') {
   config.documentId = uploadedDocumentId;
+}
+if (
+  config.detectedColorMode !== 'colored' &&
+  config.detectedColorMode !== 'grayscale'
+) {
+  config.detectedColorMode = null;
 }
 currentPrintQuote = config.mode === 'print' ? (config.quote ?? null) : null;
 const currentPaymentFingerprint = JSON.stringify({
@@ -259,6 +266,22 @@ function getDisplayColorMode(): 'colored' | 'grayscale' {
   return config.colorMode;
 }
 
+function formatColorMode(mode: 'colored' | 'grayscale'): string {
+  return mode === 'colored' ? 'Colored' : 'Grayscale';
+}
+
+function getColorModeSummaryLabel(): string {
+  if (
+    config.mode === 'print' &&
+    config.detectedColorMode &&
+    config.detectedColorMode !== config.colorMode
+  ) {
+    return `Detected: ${formatColorMode(config.detectedColorMode)} | Selected: ${formatColorMode(config.colorMode)}`;
+  }
+
+  return formatColorMode(getDisplayColorMode());
+}
+
 function calculateLegacyTotalPrice(pricing: PricingResponse): number {
   if (config.mode === 'scan') {
     return pricing.scanDocument ?? DEFAULT_PRICING.scanDocument;
@@ -309,7 +332,7 @@ if (fileValue)
       : config.mode === 'copy'
         ? 'Physical document copy'
         : (config.scanFilename ?? 'Scanned document');
-if (colorValue) colorValue.textContent = getDisplayColorMode();
+if (colorValue) colorValue.textContent = getColorModeSummaryLabel();
 if (copiesValue) copiesValue.textContent = String(config.copies);
 if (pagesValue) pagesValue.textContent = pageRangeLabel(config.pageRange);
 if (orientationValue) orientationValue.textContent = config.orientation;
@@ -650,7 +673,7 @@ async function loadPricing(): Promise<void> {
       pricingLoaded = true;
       pricingError = null;
       if (priceValue) priceValue.textContent = `₱ ${totalPrice}`;
-      if (colorValue) colorValue.textContent = getDisplayColorMode();
+      if (colorValue) colorValue.textContent = getColorModeSummaryLabel();
       if (pagesValue) {
         pagesValue.textContent = `${pageRangeLabel(config.pageRange)} (${payload.quote.selectedPages} of ${payload.quote.totalPages})`;
       }
@@ -665,7 +688,7 @@ async function loadPricing(): Promise<void> {
       pricingLoaded = false;
       pricingError = message;
       if (priceValue) priceValue.textContent = 'Unavailable';
-      if (colorValue) colorValue.textContent = config.colorMode;
+      if (colorValue) colorValue.textContent = getColorModeSummaryLabel();
       if (pagesValue) pagesValue.textContent = pageRangeLabel(config.pageRange);
       updateChangeDisplay(currentBalance);
       syncCoinSlotLockState();
@@ -983,7 +1006,7 @@ function showModal(): void {
         ? (uploadedFile ?? 'No file')
         : 'Physical document copy';
   if (modalMode) modalMode.textContent = config.mode.toUpperCase();
-  if (modalColor) modalColor.textContent = getDisplayColorMode();
+  if (modalColor) modalColor.textContent = getColorModeSummaryLabel();
   if (modalCopies) modalCopies.textContent = String(config.copies);
   if (modalPages) {
     const baseLabel = pageRangeLabel(config.pageRange);

--- a/src/services/color-detection.ts
+++ b/src/services/color-detection.ts
@@ -120,6 +120,11 @@ function isPdfImageObject(value: unknown): value is PdfImageObject {
   );
 }
 
+function isPendingPdfObjectLookupError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /isn't resolved yet/i.test(error.message);
+}
+
 async function resolveImageObject(
   page: PdfPageProxy,
   imageName: string,
@@ -127,7 +132,31 @@ async function resolveImageObject(
   const objs = page.objs;
   if (!objs || typeof objs.get !== 'function') return null;
 
-  const immediate = objs.get(imageName);
+  let immediate: unknown = null;
+  let immediateLookupError: unknown = null;
+  try {
+    immediate = objs.get(imageName);
+  } catch (error) {
+    immediateLookupError = error;
+  }
+
+  if (
+    immediateLookupError &&
+    !isPendingPdfObjectLookupError(immediateLookupError)
+  ) {
+    console.warn(
+      '[colorDetection] Unexpected image lookup error, skipping image object.',
+      {
+        imageName,
+        error:
+          immediateLookupError instanceof Error
+            ? immediateLookupError.message
+            : String(immediateLookupError),
+      },
+    );
+    return null;
+  }
+
   if (isPdfImageObject(immediate)) {
     return immediate;
   }
@@ -184,7 +213,10 @@ function getImageColorStats(image: PdfImageObject): ImageColorStats {
     };
   }
 
-  const stride = Math.max(1, Math.floor(totalPixels / IMAGE_SAMPLE_PIXEL_TARGET));
+  const stride = Math.max(
+    1,
+    Math.floor(totalPixels / IMAGE_SAMPLE_PIXEL_TARGET),
+  );
   let sampledPixels = 0;
   let colorPixels = 0;
 
@@ -229,12 +261,13 @@ export async function detectPdfColorContent(
   }
 
   try {
-    const pdfjs = (await import('pdfjs-dist/legacy/build/pdf.mjs')) as unknown as {
-      OPS: PdfOps;
-      getDocument(src: { data: Uint8Array; verbosity: number }): {
-        promise: Promise<PdfDocumentProxy>;
+    const pdfjs =
+      (await import('pdfjs-dist/legacy/build/pdf.mjs')) as unknown as {
+        OPS: PdfOps;
+        getDocument(src: { data: Uint8Array; verbosity: number }): {
+          promise: Promise<PdfDocumentProxy>;
+        };
       };
-    };
     const OPS = pdfjs.OPS;
 
     const data = new Uint8Array(fs.readFileSync(pdfPath));


### PR DESCRIPTION
# #99 Implemented Grayscale Detection Reversion User Option

This pull request enhances the print and confirm flows by introducing auto-detection of a document's color mode (colored or grayscale), surfacing this information in the UI, and improving how color-related choices and notices are presented to the user. The changes ensure that if a document is detected as grayscale, the UI advises the user but still allows them to override the color mode if desired.

**Color Mode Detection and Propagation:**

- Added a new `detectedColorMode` property to both the print (`PrintConfig`) and confirm (`ConfirmConfig`) configuration objects to track the auto-detected color mode for a document.
- The detected color mode is set based on the result of the color analysis API and is reset appropriately on errors or when re-analyzing.
- This property is passed through the print flow and validated/normalized in the confirm flow to ensure it is either `'colored'`, `'grayscale'`, or `null`. 

**User Interface and Experience Improvements:**

- When a document is detected as grayscale, the UI now displays an advisory notice but keeps the color selection controls enabled, allowing the user to override the suggestion. The notice text was updated to be more user-friendly.
- The summary and confirmation screens now show both the detected and selected color modes if they differ, improving transparency for the user. This is handled by a new `getColorModeSummaryLabel()` function and is used consistently throughout the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic color mode detection: The app now detects whether content should be printed in grayscale or color and displays an advisory notice when grayscale is recommended.
  * Enhanced color mode display: When the detected color mode differs from your manual selection, both are shown together for clarity.
  * Manual override control: You retain full ability to override any automatically detected color preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->