### PR TITLE
refactor: PrintPreview display logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 4.6.13
       i18next:
         specifier: ^25.9.0
-        version: 25.9.0(typescript@5.9.3)
+        version: 25.9.0(typescript@6.0.2)
       i18next-fs-backend:
         specifier: ^2.6.1
         version: 2.6.1
@@ -98,16 +98,16 @@ importers:
         version: 0.27.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@6.0.2)
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@5.9.3)
+        version: 2.0.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@6.0.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
 
 packages:
 
@@ -1646,8 +1646,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2629,11 +2629,11 @@ snapshots:
 
   i18next-http-middleware@3.9.2: {}
 
-  i18next@25.9.0(typescript@5.9.3):
+  i18next@25.9.0(typescript@6.0.2):
     dependencies:
       '@babel/runtime': 7.29.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3159,7 +3159,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-node-dev@2.0.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@5.9.3):
+  ts-node-dev@2.0.0(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@6.0.2):
     dependencies:
       chokidar: 3.6.0
       dynamic-dedupe: 0.3.0
@@ -3169,15 +3169,15 @@ snapshots:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@6.0.2)
       tsconfig: 7.0.0
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
 
-  ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@25.3.0)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -3191,7 +3191,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -3229,7 +3229,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   uint8array-extras@1.5.0: {}
 

--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -178,9 +178,15 @@ class PrintPreview {
   private pdfDoc: PDFDocumentProxy | null = null;
   private currentPage = 1;
   private totalPages = 1;
+  private latestImageInfo: { naturalWidth: number; naturalHeight: number } | null =
+    null;
 
   get pageCount(): number {
     return this.totalPages;
+  }
+
+  get imageInfo(): { naturalWidth: number; naturalHeight: number } | null {
+    return this.latestImageInfo;
   }
 
   private renderTask: Promise<void> | null = null;
@@ -270,6 +276,7 @@ class PrintPreview {
     this.showImg(false);
     this.showFrame(false);
     this.setHint('Loading preview…');
+    this.latestImageInfo = null;
 
     let url = `/api/wireless/sessions/${encodeURIComponent(sessionId)}/preview`;
     if (filename) url += `?filename=${encodeURIComponent(filename)}`;
@@ -328,15 +335,18 @@ class PrintPreview {
       });
       await this.loadImage(blobUrl, true);
     } else if (contentType.includes('application/pdf')) {
+      this.latestImageInfo = null;
       const buf = await response.arrayBuffer();
       previewLog('pdf buffer loaded', { bytes: buf.byteLength });
       await this.loadPdf(buf);
     } else if (contentType.includes('text/html')) {
+      this.latestImageInfo = null;
       const html = await response.text();
       previewLog('html preview loaded', { chars: html.length });
       this.loadHtml(html);
     } else {
       previewLog('unsupported preview content type', { contentType });
+      this.latestImageInfo = null;
       this.showError('Unsupported preview format.');
     }
   }
@@ -428,6 +438,7 @@ class PrintPreview {
     return new Promise((resolve) => {
       const timeoutId = window.setTimeout(() => {
         previewLog('loadImage() timeout');
+        this.latestImageInfo = null;
         this.showError('Image preview timed out. Please retry.');
         if (isBlobUrl) URL.revokeObjectURL(url);
         resolve();
@@ -435,6 +446,10 @@ class PrintPreview {
 
       this.img.onload = () => {
         window.clearTimeout(timeoutId);
+        this.latestImageInfo = {
+          naturalWidth: this.img.naturalWidth,
+          naturalHeight: this.img.naturalHeight,
+        };
         previewLog('loadImage() onload', {
           naturalWidth: this.img.naturalWidth,
           naturalHeight: this.img.naturalHeight,
@@ -451,6 +466,7 @@ class PrintPreview {
       };
       this.img.onerror = () => {
         window.clearTimeout(timeoutId);
+        this.latestImageInfo = null;
         previewLog('loadImage() onerror');
         this.showError('Could not load image.');
         if (isBlobUrl) URL.revokeObjectURL(url);
@@ -545,6 +561,7 @@ class PrintPreview {
 
   private showError(msg: string): void {
     previewLog('showError()', { message: msg });
+    this.latestImageInfo = null;
     this.showLoading(false);
     this.showCanvas(false);
     this.showImg(false);
@@ -728,6 +745,11 @@ if (mode === 'copy' && continueBtn) {
 
 let currentPrintQuote: PrintQuote | null = null;
 let detectedColorMode: ColorMode | null = null;
+let detectedOrientation: Orientation | null = null;
+let currentOrientationDetectionKey: string | null = null;
+const orientationAutoAppliedKeys = new Set<string>();
+const orientationManuallyAdjustedKeys = new Set<string>();
+let suppressOrientationChangeTracking = false;
 let quoteError: string | null = null;
 let quoteLoading = false;
 let quoteRequestVersion = 0;
@@ -959,6 +981,98 @@ function getCopies(): number {
   );
 }
 
+function orientationDetectionKey(): string | null {
+  if (mode !== 'print' || !sessionId) return null;
+  const id = selectedDocumentId ?? selectedFile;
+  if (!id) return null;
+  return `${sessionId}:${id}`;
+}
+
+function clearOrientationNotice(): void {
+  document.querySelector('.orientation-detect-notice')?.remove();
+}
+
+function syncOrientationDetectionContext(): string | null {
+  const key = orientationDetectionKey();
+  if (key !== currentOrientationDetectionKey) {
+    currentOrientationDetectionKey = key;
+    detectedOrientation = null;
+    clearOrientationNotice();
+  }
+  return key;
+}
+
+function showOrientationNotice(detected: Orientation): void {
+  const orientationGroup = document.querySelector<HTMLElement>(
+    '.option-group:has(input[name="orientation"])',
+  );
+  if (!orientationGroup) return;
+
+  let notice = orientationGroup.querySelector<HTMLElement>(
+    '.orientation-detect-notice',
+  );
+  if (!notice) {
+    notice = document.createElement('p');
+    notice.className = 'orientation-detect-notice';
+    orientationGroup.appendChild(notice);
+  }
+
+  const detectedLabel = detected === 'landscape' ? 'landscape' : 'portrait';
+  const oppositeLabel = detected === 'landscape' ? 'Portrait' : 'Landscape';
+  notice.textContent = `Auto-detected ${detectedLabel} orientation. Switch to ${oppositeLabel} if this looks wrong.`;
+}
+
+function applyImageOrientationDetection(): void {
+  if (mode !== 'print') {
+    detectedOrientation = null;
+    clearOrientationNotice();
+    return;
+  }
+
+  const key = syncOrientationDetectionContext();
+  if (!key) {
+    detectedOrientation = null;
+    clearOrientationNotice();
+    return;
+  }
+
+  const imageInfo = preview.imageInfo;
+  if (!imageInfo || imageInfo.naturalWidth <= 0 || imageInfo.naturalHeight <= 0) {
+    detectedOrientation = null;
+    clearOrientationNotice();
+    return;
+  }
+
+  detectedOrientation =
+    imageInfo.naturalWidth > imageInfo.naturalHeight ? 'landscape' : 'portrait';
+  showOrientationNotice(detectedOrientation);
+
+  if (
+    orientationManuallyAdjustedKeys.has(key) ||
+    orientationAutoAppliedKeys.has(key)
+  ) {
+    return;
+  }
+
+  const selected = (getRadio('orientation') as Orientation) || 'portrait';
+  if (selected !== detectedOrientation) {
+    const target = document.querySelector<HTMLInputElement>(
+      `input[name="orientation"][value="${detectedOrientation}"]`,
+    );
+    if (target) {
+      suppressOrientationChangeTracking = true;
+      try {
+        target.checked = true;
+        target.dispatchEvent(new Event('change', { bubbles: true }));
+      } finally {
+        suppressOrientationChangeTracking = false;
+      }
+    }
+  }
+
+  orientationAutoAppliedKeys.add(key);
+}
+
 function currentPreviewConfig(): PreviewConfig {
   return {
     colorMode: (getRadio('colorMode') as ColorMode) || 'colored',
@@ -1144,6 +1258,17 @@ document
     });
   });
 
+document
+  .querySelectorAll<HTMLInputElement>('input[name="orientation"]')
+  .forEach((el) => {
+    el.addEventListener('change', () => {
+      if (suppressOrientationChangeTracking) return;
+      const key = orientationDetectionKey();
+      if (!key) return;
+      orientationManuallyAdjustedKeys.add(key);
+    });
+  });
+
 copiesDec?.addEventListener('click', () => {
   const v = getCopies();
   if (v > 1 && copiesInput) {
@@ -1182,6 +1307,8 @@ async function loadPreview(): Promise<void> {
     selectedDocumentId: selectedDocumentId ?? null,
   });
   if (mode === 'copy') {
+    clearOrientationNotice();
+    detectedOrientation = null;
     const copyPreview = copyPreviewPath;
     if (!copyPreview) return;
 
@@ -1219,7 +1346,11 @@ async function loadPreview(): Promise<void> {
     return;
   }
 
-  if (mode !== 'print') return;
+  if (mode !== 'print') {
+    clearOrientationNotice();
+    detectedOrientation = null;
+    return;
+  }
 
   if (!sessionId) {
     // Show error state in the paper placeholder
@@ -1229,8 +1360,11 @@ async function loadPreview(): Promise<void> {
     return;
   }
 
+  syncOrientationDetectionContext();
   await preview.load(sessionId, selectedFile ?? undefined);
   previewLog('preview.load() complete');
+  applyImageOrientationDetection();
+  previewLog('applyImageOrientationDetection() complete');
   if (sessionId) await applyColorAnalysis(sessionId, selectedFile);
   previewLog('applyColorAnalysis() complete');
   syncPageRangeAvailability();

--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -513,10 +513,10 @@ class PrintPreview {
 
   private showFrame(on: boolean): void {
     this.iframe.style.display = on ? 'block' : 'none';
+    this.placeholder.classList.toggle('hidden', !on);
     if (on) {
       this.canvas.style.display = 'none';
       this.imgStage.style.display = 'none';
-      this.placeholder.classList.add('hidden');
     }
   }
 
@@ -526,10 +526,10 @@ class PrintPreview {
 
   private showCanvas(on: boolean): void {
     this.canvas.style.display = on ? 'block' : 'none';
+    this.placeholder.classList.toggle('hidden', !on);
     if (on) {
       this.iframe.style.display = 'none';
       this.imgStage.style.display = 'none';
-      this.placeholder.classList.add('hidden');
     }
   }
 

--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -529,7 +529,7 @@ class PrintPreview {
 
   private showFrame(on: boolean): void {
     this.iframe.style.display = on ? 'block' : 'none';
-    this.placeholder.classList.toggle('hidden', !on);
+    this.placeholder.classList.toggle('hidden', on);
     if (on) {
       this.canvas.style.display = 'none';
       this.imgStage.style.display = 'none';
@@ -542,7 +542,7 @@ class PrintPreview {
 
   private showCanvas(on: boolean): void {
     this.canvas.style.display = on ? 'block' : 'none';
-    this.placeholder.classList.toggle('hidden', !on);
+    this.placeholder.classList.toggle('hidden', on);
     if (on) {
       this.iframe.style.display = 'none';
       this.imgStage.style.display = 'none';

--- a/src/public/config/app.ts
+++ b/src/public/config/app.ts
@@ -443,8 +443,6 @@ class PrintPreview {
         this.currentPage = 1;
         this.updatePager();
         this.showImg(true);
-        this.showCanvas(false);
-        this.showFrame(false);
         this.showLoading(false);
         this.setHint('Image preview');
         // Revoke blob URL after image loads to free memory
@@ -515,7 +513,11 @@ class PrintPreview {
 
   private showFrame(on: boolean): void {
     this.iframe.style.display = on ? 'block' : 'none';
-    this.placeholder.classList.toggle('hidden', on);
+    if (on) {
+      this.canvas.style.display = 'none';
+      this.imgStage.style.display = 'none';
+      this.placeholder.classList.add('hidden');
+    }
   }
 
   private showLoading(on: boolean): void {
@@ -524,8 +526,11 @@ class PrintPreview {
 
   private showCanvas(on: boolean): void {
     this.canvas.style.display = on ? 'block' : 'none';
-    if (on) this.iframe.style.display = 'none';
-    this.placeholder.classList.toggle('hidden', on);
+    if (on) {
+      this.iframe.style.display = 'none';
+      this.imgStage.style.display = 'none';
+      this.placeholder.classList.add('hidden');
+    }
   }
 
   private showImg(on: boolean): void {
@@ -1287,7 +1292,10 @@ async function applyColorAnalysis(
 
   let url = `/api/wireless/sessions/${encodeURIComponent(sessionId)}/color-analysis`;
   if (filename) url += `?filename=${encodeURIComponent(filename)}`;
-  previewLog('applyColorAnalysis() start', { sessionId, filename: filename ?? null });
+  previewLog('applyColorAnalysis() start', {
+    sessionId,
+    filename: filename ?? null,
+  });
 
   try {
     const resp = await fetchWithTimeout(url, 10_000);

--- a/src/public/config/styles.css
+++ b/src/public/config/styles.css
@@ -614,7 +614,8 @@ body {
 }
 
 /* Grayscale auto-lock notice */
-.color-lock-notice {
+.color-lock-notice,
+.orientation-detect-notice {
   font-size: 11px;
   font-weight: 500;
   color: var(--lavender);


### PR DESCRIPTION
# #98 Implemented Image File Missing Preview

This pull request refines the logic for displaying preview elements in the `PrintPreview` class. The update ensures compatibility with the latest TypeScript features, and the UI changes improve how different preview modes are shown or hidden.

UI logic improvements in `PrintPreview`:

* Enhanced the `showFrame` and `showCanvas` methods to ensure that when either the frame or canvas is shown, the other preview elements (`canvas`, `imgStage`, `iframe`, and `placeholder`) are hidden, preventing overlapping displays and improving user experience.
* Removed redundant calls to `showCanvas(false)` and `showFrame(false)` in the image preview logic, as these are now handled by the improved show/hide logic.

Code style:

* Minor formatting improvement in `applyColorAnalysis` for better readability of debug logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript development tooling to version 6.0.2

* **New Features**
  * Print preview now captures and retains the most recently loaded image’s intrinsic dimensions.
  * Added client-side auto-orientation detection in print mode with a notice and respect for manual overrides.

* **Bug Fixes**
  * Improved preview element visibility handling across image/canvas/iframe modes for more consistent rendering.

* **Style**
  * Added styling for the orientation-detection notice to match existing notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->