### PR TITLE
feat(print): Implement print dispatcher for enhanced printing capabilities

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -417,6 +417,23 @@ Both `/api/admin/summary` and `/api/admin/status` now include:
 }
 ```
 
+### `GET /api/admin/print-dispatch/latency`
+
+Returns print dispatcher latency analytics derived from admin logs by correlating:
+
+- `print_dispatch_summary` (dispatch timestamp + MIME/engine), and
+- spooler terminal logs (`print_spooler_confirmed`, `print_spooler_job_failed`, `print_spooler_auto_refund`, `print_spooler_monitor_timeout`, `print_spooler_monitor_unavailable`).
+
+Query:
+
+- `maxEvents` (optional, default `5000`, clamped `100..20000`)
+
+Response includes:
+
+- `byMimeType[]` with `p50`, `p95`, and `sampleCount`
+- `byEngine[]` with `p50`, `p95`, and `sampleCount`
+- `speculation` summary where `confirmed=true` when worst non-PDF p95 is at least 30% higher than PDF p95
+
 ### `GET /api/admin/transactions/:transactionId`
 
 Returns a transaction-focused support snapshot for the given reference ID. Response includes:
@@ -550,6 +567,13 @@ Forces immediate printer re-detection and telemetry refresh. Returns `{ ok, prin
 ### `POST /api/admin/printer/test-print`
 
 Prints a diagnostic test page to the currently connected printer.
+
+Response includes dispatch timing metadata:
+
+- `timing.totalElapsedMs` — end-to-end request handling time
+- `timing.dispatchDurationMs` — dispatcher engine handoff duration
+- `timing.dispatchEngine` — selected engine (`sumatra`, `pdftoprinter`, `ghostscript`, `libreoffice`)
+- `timing.dispatchAttempts` — number of dispatch attempts in the fallback chain
 
 ### `GET /api/admin/logs`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,8 @@ The backend serves pages, exposes APIs, and coordinates print/copy/scan/payment 
 - `hopper.ts`: coin hopper orchestration — dispense with retries, stats tracking, owed-change fallback.
 - `hopper-protocol.ts`: Arduino hopper serial protocol contract (command builders, response parser, error codes).
 - `settlement.ts`: shared payment settlement logic (charge balance + dispense change) used by print and copy flows.
-- `printer.ts`: SumatraPDF-based print dispatch.
+- `printer.ts` + `print-dispatcher.ts`: mode-based print dispatch orchestration
+  (`legacy`, `phased`, `new-only`) with engine adapters.
 - `session.ts`: in-memory wireless upload session domain.
 - `hotspot.ts`: MyPublicWiFi process/config integration.
 - `scanner.ts`: scanner adapter integration.
@@ -119,7 +120,8 @@ Ephemeral (process memory):
 ## External dependencies
 
 - MyPublicWiFi (hotspot + captive behavior)
-- SumatraPDF executable for print dispatch
+- PDFtoPrinter, GhostScript, and LibreOffice binaries for print dispatch
+- Optional Sumatra fallback in phased mode
 - Serial device for coin input + coin hopper (shared 115200-baud line via Arduino Uno)
 - Scanner hardware adapter
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,9 @@ pnpm run db:migrate:legacy
 - Avoid destructive changes to runtime artifacts:
   - `uploads/`
   - `printbit.sqlite`
-- Printing depends on `bin/SumatraPDF.exe`; do not change printer integration casually.
+- Printing uses a mode-based dispatcher (`legacy|phased|new-only`) and external binaries
+  (`PDFtoPrinter`, `GhostScript`, `LibreOffice`, optional Sumatra fallback); do not
+  change printer integration casually.
 - Serial/hotspot/scanner behavior should degrade gracefully when hardware is unavailable.
 
 ## API and validation expectations
@@ -57,7 +59,7 @@ pnpm run db:migrate:legacy
 There is currently no formal test suite configured.
 For every change, at minimum:
 
-1. Run `pnpm exec tsc --noEmit`.
+1. Run `pnpm exec tsc --noEmit --ignoreDeprecations 6.0`.
 2. Manually verify the affected UI/API flow.
 3. Confirm no regressions in print, upload, or admin behavior related to your change.
 

--- a/INSTALLATIONS.md
+++ b/INSTALLATIONS.md
@@ -17,7 +17,10 @@ This guide explains what software to install, what dependencies are used, and ho
 
 ## Kiosk/production integrations
 
-- **SumatraPDF portable executable** at: `bin/SumatraPDF.exe` (used for print dispatch).
+- **PDFtoPrinter** at: `bin/PDFtoPrinter.exe` (or configured via `PRINTBIT_PDFTOPRINTER_PATH`).
+- **GhostScript** (`gswin64c.exe`) installed and discoverable via PATH or `PRINTBIT_GHOSTSCRIPT_PATH`.
+- **LibreOffice** (`soffice.exe`) installed and discoverable via PATH or `PRINTBIT_LIBREOFFICE_PATH`.
+- **Optional phased fallback:** SumatraPDF portable executable at `bin/SumatraPDF.exe` (or `PRINTBIT_SUMATRA_PATH`).
 - **MyPublicWiFi** (used for hotspot/captive behavior integration).
 - **Printer driver package** for the production printer model.
 - **Scanner driver package / TWAIN/WIA support** for the scanner model.
@@ -66,12 +69,16 @@ pnpm run build
 5\. Type-check:
 
 ```bash
-pnpm exec tsc --noEmit
+pnpm exec tsc --noEmit --ignoreDeprecations 6.0
 ```
 
 ## 5) Preflight checklist (recommended)
 
-- `bin/SumatraPDF.exe` exists.
+- `PRINTBIT_PRINT_DISPATCH_MODE` is set appropriately (`legacy`, `phased`, or `new-only`).
+- `bin/PDFtoPrinter.exe` exists (or `PRINTBIT_PDFTOPRINTER_PATH` points to a valid file).
+- GhostScript (`gswin64c.exe`) is reachable by PATH or `PRINTBIT_GHOSTSCRIPT_PATH`.
+- LibreOffice (`soffice.exe`) is reachable by PATH or `PRINTBIT_LIBREOFFICE_PATH`.
+- If using `phased`, Sumatra fallback path is valid (`bin/SumatraPDF.exe` or `PRINTBIT_SUMATRA_PATH`).
 - Printer appears online in Windows.
 - Scanner is recognized by Windows/scanner APIs.
 - Serial coin/hopper controller is connected and readable.
@@ -85,7 +92,8 @@ pnpm exec tsc --noEmit
   - Ensure supported Node version is installed.
   - Reinstall dependencies after Node changes: `pnpm install`.
 - **Printing fails:**
-  - Verify `bin/SumatraPDF.exe` path and printer driver availability.
+  - Verify dispatcher mode (`PRINTBIT_PRINT_DISPATCH_MODE`) and binary paths.
+  - Verify printer driver availability and default printer configuration.
 - **Scanner endpoints fail:**
   - Confirm scanner drivers and device permissions.
 - **Hotspot features unavailable:**

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -4,7 +4,7 @@
 
 - Start dev server: `pnpm dev`
 - Build client bundle: `pnpm build`
-- Type-check: `pnpm exec tsc --noEmit`
+- Type-check: `pnpm exec tsc --noEmit --ignoreDeprecations 6.0`
 - Run one-time legacy JSON->SQLite import: `pnpm run db:migrate:legacy`
 - Force rerun legacy import (clears import marker): `pnpm run db:migrate:legacy -- --force`
 - Apply controlled updates policy: `pnpm run updates:apply`
@@ -19,7 +19,12 @@
 
 ## Pre-flight checklist (kiosk)
 
-1. `bin/SumatraPDF.exe` exists.
+1. Print dispatcher dependencies are available for the configured mode:
+   - `PRINTBIT_PRINT_DISPATCH_MODE=legacy|phased|new-only`
+   - `bin/PDFtoPrinter.exe` (or `PRINTBIT_PDFTOPRINTER_PATH`)
+   - GhostScript (`gswin64c.exe`) via PATH or `PRINTBIT_GHOSTSCRIPT_PATH`
+   - LibreOffice (`soffice.exe`) via PATH or `PRINTBIT_LIBREOFFICE_PATH`
+   - Optional Sumatra fallback (`bin/SumatraPDF.exe` or `PRINTBIT_SUMATRA_PATH`) for phased mode
 2. Printer is installed and has a default printer selected.
 3. Serial coin hardware is connected (if coin mode is used).
 4. Scanner is connected (for copy/scan features).
@@ -173,9 +178,23 @@ All sections below must pass before closing spooler handoff reliability work.
 
 ## Print fails
 
-- Verify `bin/SumatraPDF.exe` path and permissions.
+- Verify print dispatcher mode and binary paths.
 - Confirm uploaded file exists in `uploads/`.
 - Check default Windows printer status.
+
+## Print dispatcher phased rollout gate (Issue #112)
+
+Use `GET /api/admin/print-dispatch/latency` to evaluate cutover readiness.
+
+Move from `PRINTBIT_PRINT_DISPATCH_MODE=phased` to `new-only` only when:
+
+1. `sampleCount` has representative traffic for both PDF and non-PDF uploads.
+2. p95 latency and failure behavior are stable across recent operating windows.
+3. If validating the slowness speculation, non-PDF p95 is interpreted as materially slower only when it is >=30% above PDF p95.
+
+Rollback path:
+
+- Set `PRINTBIT_PRINT_DISPATCH_MODE=legacy` and restart the service.
 
 ## Ink / toner levels show "N/A"
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Related env knobs:
 - `PRINTBIT_ESP32_COIN_API_KEY` (**required in `esp32` mode**) shared secret required by `/coin` bridge requests
 - `PRINTBIT_ESP32_COIN_BRIDGE_RELAXED` (default `false`) simulation-only compatibility mode for legacy `/coin?value=` requests
 - `PRINTBIT_ESP32_ALWAYS_ACCEPT_COINS` (default `true` in `esp32` mode) accepts coin credits even when slot/printer safety gates are active so kiosk UI balance keeps updating from ESP32 events
-- `PRINTBIT_TRUSTED_TIME_ENFORCE` (default `false` in `esp32` mode, else `true`) blocks or allows financial operations when trusted time cannot sync
+- `PRINTBIT_TRUSTED_TIME_ENFORCE` (default `false`) blocks or allows financial operations when trusted time cannot sync
 - `PRINTBIT_SERIAL_PORT` (optional) to pin the serial coin/hopper device when multiple COM ports are present
 
 Recommended `.env` for ESP32 mode:
@@ -218,6 +218,10 @@ Recommended `.ino` alignment for ESP32 mode:
   - `x-coin-source: esp32`
   - `x-coin-api-key: <same as PRINTBIT_ESP32_COIN_API_KEY>`
   - `x-coin-event-id: <unique id per coin>`
+- For hopper change dispensing, support authenticated commands:
+  - `POST /hopper/dispense` with `token`, `coins`, optional `requestId`
+  - `GET /hopper/status?token=...` for live dispense state
+  - Use the same shared secret as `PRINTBIT_ESP32_COIN_API_KEY` (`hopperControlToken` in `.ino`)
 
 Troubleshooting mobile captive onboarding:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Troubleshooting:
 - **Backend:** Node.js, Express, Socket.IO, TypeScript
 - **Storage:** SQLite (`printbit.sqlite`) for persisted kiosk state
 - **Upload handling:** Multer
-- **Printing:** SumatraPDF portable executable (`bin/SumatraPDF.exe`)
+- **Printing:** Phased dispatcher (`PDFtoPrinter`, `GhostScript`, `LibreOffice`, with optional Sumatra fallback)
 - **Serial integration:** `serialport`
 - **Frontend:** Static HTML/CSS + TypeScript bundles under `src/public`
 
@@ -95,7 +95,7 @@ pnpm run build
 ### 4) Type-check
 
 ```bash
-pnpm exec tsc --noEmit
+pnpm exec tsc --noEmit --ignoreDeprecations 6.0
 ```
 
 ### 5) One-time legacy import (optional)
@@ -124,17 +124,34 @@ src/
   public/                   # Browser UI pages (print/upload/config/confirm/copy/scan/admin)
 uploads/                    # Runtime uploaded files
 printbit.sqlite             # Runtime persisted machine state (SQLite)
-bin/                        # External executables (ex: SumatraPDF.exe)
+  bin/                        # External executables (ex: PDFtoPrinter.exe, SumatraPDF.exe)
 ```
 
 ## Runtime prerequisites
 
 - Windows machine (required for current hardware/print/hotspot integrations).
-- `bin/SumatraPDF.exe` present for print dispatch.
+- Print dispatch dependencies configured for your selected mode:
+  - `bin/PDFtoPrinter.exe` (or `PRINTBIT_PDFTOPRINTER_PATH`)
+  - GhostScript (`PRINTBIT_GHOSTSCRIPT_PATH` or PATH `gswin64c`)
+  - LibreOffice (`PRINTBIT_LIBREOFFICE_PATH` or PATH `soffice`)
+  - Optional Sumatra fallback (`bin/SumatraPDF.exe` or `PRINTBIT_SUMATRA_PATH`) for phased mode
 - Optional but expected in production:
   - Coin acceptor serial device
   - Scanner device
   - MyPublicWiFi installation
+
+### Print dispatcher configuration
+
+- `PRINTBIT_PRINT_DISPATCH_MODE=legacy|phased|new-only` (default `legacy`)
+  - `legacy`: Sumatra-only behavior
+  - `phased`: PDFtoPrinter/GhostScript/LibreOffice with Sumatra emergency fallback
+  - `new-only`: PDFtoPrinter/GhostScript/LibreOffice only
+- `PRINTBIT_PDFTOPRINTER_PATH` (or `PDFTOPRINTER_PATH`) default: `bin/PDFtoPrinter.exe`
+- `PRINTBIT_GHOSTSCRIPT_PATH` (or `GHOSTSCRIPT_PATH`) optional explicit path to `gswin64c.exe`
+- `PRINTBIT_LIBREOFFICE_PATH` (or `LIBREOFFICE_PATH`) optional explicit path to `soffice.exe`
+- `PRINTBIT_SUMATRA_PATH` (or `SUMATRA_PATH`) optional Sumatra fallback path
+- `PRINTBIT_PRINT_DISPATCH_TIMEOUT_MS` (default `60000`)
+- `PRINTBIT_PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS` (default `120000`, minimum 10s)
 
 ## Mobile and network matrix
 
@@ -166,6 +183,7 @@ Related env knobs:
 - `PRINTBIT_ESP32_COIN_API_KEY` (**required in `esp32` mode**) shared secret required by `/coin` bridge requests
 - `PRINTBIT_ESP32_COIN_BRIDGE_RELAXED` (default `false`) simulation-only compatibility mode for legacy `/coin?value=` requests
 - `PRINTBIT_ESP32_ALWAYS_ACCEPT_COINS` (default `true` in `esp32` mode) accepts coin credits even when slot/printer safety gates are active so kiosk UI balance keeps updating from ESP32 events
+- `PRINTBIT_TRUSTED_TIME_ENFORCE` (default `false` in `esp32` mode, else `true`) blocks or allows financial operations when trusted time cannot sync
 - `PRINTBIT_SERIAL_PORT` (optional) to pin the serial coin/hopper device when multiple COM ports are present
 
 Recommended `.env` for ESP32 mode:
@@ -185,6 +203,8 @@ PRINTBIT_ESP32_COIN_API_KEY=printbit-coin-bridge-key
 PRINTBIT_ESP32_COIN_BRIDGE_RELAXED=false
 # Optional: keep ESP32 coin credits flowing even during printer/slot safety gates
 PRINTBIT_ESP32_ALWAYS_ACCEPT_COINS=true
+# Optional: turn on only when kiosk has stable NTP/internet access
+PRINTBIT_TRUSTED_TIME_ENFORCE=false
 ```
 
 Security note: `printbit-coin-bridge-key` is a predictable example value. Before deployment, generate a unique secret for `PRINTBIT_ESP32_COIN_API_KEY`, set it in the kiosk environment, and use the same value in ESP32 firmware (`coinBridgeApiKey` in `esp32-captive-portal.ino`). Do not reuse the default key in production.

--- a/WINDOWS_KIOSK_LOCKDOWN_SETUP.md
+++ b/WINDOWS_KIOSK_LOCKDOWN_SETUP.md
@@ -16,7 +16,11 @@ Install these first:
 - pnpm `10.13.1`
 - Git
 - Microsoft Edge (latest stable)
-- `bin/SumatraPDF.exe` present in project
+- Print dispatcher binaries available for selected mode:
+  - `bin/PDFtoPrinter.exe` (or `PRINTBIT_PDFTOPRINTER_PATH`)
+  - GhostScript (`gswin64c.exe`) via PATH or `PRINTBIT_GHOSTSCRIPT_PATH`
+  - LibreOffice (`soffice.exe`) via PATH or `PRINTBIT_LIBREOFFICE_PATH`
+  - Optional Sumatra fallback (`bin/SumatraPDF.exe` or `PRINTBIT_SUMATRA_PATH`) for phased mode
 - Printer driver package (production printer)
 - Scanner driver + NAPS2 (`C:\Program Files\NAPS2\NAPS2.Console.exe`)
 - Serial/USB drivers for coin acceptor / hopper controller
@@ -55,7 +59,7 @@ From the project root:
 ```powershell
 pnpm install
 pnpm run build
-pnpm exec tsc --noEmit
+pnpm exec tsc --noEmit --ignoreDeprecations 6.0
 ```
 
 Validate launcher scripts exist:

--- a/docs/superpowers/specs/2026-04-09-print-dispatcher-sumatra-replacement-design.md
+++ b/docs/superpowers/specs/2026-04-09-print-dispatcher-sumatra-replacement-design.md
@@ -1,0 +1,160 @@
+# Print Dispatcher Migration Design (#112)
+
+## Problem statement
+
+Print dispatch currently depends on `bin/SumatraPDF.exe` via `src/services/printer.ts`, while uploaded files include PDF, Office documents, and images. This creates a reliability and latency risk for non-PDF formats and blocks controlled routing by format/engine.
+
+This design introduces a phased replacement with fallback so we can reduce dispatch failures and validate whether non-PDF workloads are materially slower than PDF in real kiosk traffic.
+
+## Scope and decisions
+
+- **Migration model:** phased rollout, not hard cutover.
+- **Primary KPI:** end-to-end latency from confirm-payment dispatch start to spooler terminal state.
+- **Supported direct-routing formats (phase 1):** PDF, DOC/DOCX, XLS/XLSX, PPT/PPTX, JPG/JPEG/PNG.
+- **Dependency policy:** PDFtoPrinter, GhostScript, LibreOffice are required for production; optional for local/dev.
+- **Temporary safety net:** keep Sumatra as emergency fallback in phase 1, then remove after metrics and stability gates pass.
+- **Speculation threshold:** non-PDF p95 is considered materially slower when it is **>=30%** above PDF p95 in comparable windows.
+
+## Current-state integration points
+
+- Current dispatch implementation: `src/services/printer.ts` (`printFile(...)` + Sumatra `execFile`).
+- Current print call sites:
+  - `src/modules/financial/financial.service.ts`
+  - `src/modules/copy/copy.service.ts`
+  - `src/modules/admin/admin.controller.ts` (test print)
+- Existing spooler lifecycle and reconciliation: `src/services/print-spooler.ts` and financial lifecycle checkpoints.
+
+## Alternatives considered
+
+1. **Instrumentation first, replacement later**
+   - Pros: smallest immediate risk.
+   - Cons: delays functional fix for non-PDF routing and fallback robustness.
+2. **Selected: PrintDispatcher now with phased fallback and telemetry**
+   - Pros: solves routing/fallback and observability together; supports controlled migration.
+   - Cons: moderate integration complexity.
+3. **External print worker service**
+   - Pros: process isolation, independent scaling.
+   - Cons: unnecessary operational complexity for current kiosk deployment.
+
+## Proposed architecture
+
+### 1) Unified dispatch service
+
+Create `src/services/print-dispatcher.ts` exposing:
+
+```ts
+dispatch(input: DispatchInput): Promise<DispatchResult>
+```
+
+Where `DispatchInput` includes:
+
+- `filePath`, `mimeType`, `extension`
+- standardized print options (`printer`, `copies`, `duplex`, `grayscale`, `pageRange`, `orientation`, `paperSize`)
+- trace context (`transactionId`, `sessionId`, `documentId`, `mode`)
+
+`DispatchResult` includes:
+
+- `success`
+- winning `engine`
+- per-attempt details (`exitCode`, `stdout`, `stderr`, `durationMs`, `timedOut`)
+- aggregate `durationMs`
+
+### 2) Engine adapters
+
+Add engine-specific adapters under `src/services/print-dispatch-engines/`:
+
+- `pdftoprinter.engine.ts`
+- `ghostscript.engine.ts`
+- `libreoffice.engine.ts`
+- `sumatra.engine.ts` (phase-1 emergency fallback only)
+
+Each adapter implements a shared interface:
+
+```ts
+run(input: DispatchInput): Promise<DispatchAttemptResult>
+```
+
+### 3) Routing and fallback policy
+
+Phase-1 chain:
+
+- **PDF:** `PDFtoPrinter -> GhostScript -> Sumatra`
+- **Office/Image:** `LibreOffice -> Sumatra` (only where Sumatra compatibility applies; otherwise fail explicitly)
+
+Routing is centralized in `print-dispatcher.ts`, keyed by extension/MIME and runtime mode.
+
+### 4) Backward-compatible surface
+
+Keep `printFile(...)` exported from `src/services/printer.ts` as a compatibility wrapper in phase 1, delegating to `PrintDispatcher` so call sites can migrate safely without a big-bang API break.
+
+## Configuration model
+
+Add config entries in the existing environment/config layer:
+
+- `PRINT_DISPATCH_MODE=legacy|phased|new-only`
+- `PDFTOPRINTER_PATH=...`
+- `GHOSTSCRIPT_PATH=...`
+- `LIBREOFFICE_PATH=...`
+- `SUMATRA_PATH=...` (phase-1 emergency fallback)
+- optional per-engine timeout settings (with safe defaults)
+
+Behavior:
+
+- **Production:** missing required new-engine binaries in `phased`/`new-only` should fail fast at startup with explicit diagnostics.
+- **Local/dev:** missing binaries degrade to `legacy` behavior with clear warnings.
+
+## Data flow and error handling
+
+1. Existing preflight checks remain unchanged (printer readiness, ink policy, analysis/quote).
+2. Dispatch invocation shifts to `PrintDispatcher`.
+3. Dispatcher executes bounded engine chain and captures attempt telemetry.
+4. If all engines fail, return typed dispatch error to existing failure path so current `print_failed` handling and malfunction signaling continue.
+5. If one engine succeeds, continue existing settlement + spooler monitoring/reconciliation flow unchanged.
+
+No settlement-order change is introduced by this design.
+
+## Observability and speculation validation
+
+Emit structured dispatch telemetry per attempt:
+
+- `attemptId`, `transactionId`, `engine`, `mimeType`, `extension`
+- `startedAt`, `durationMs`, `exitCode`, `timedOut`, `success`
+- normalized error classification and stderr hash/sanitized snippet
+
+Persist/aggregate enough data to compute:
+
+- p50/p95 end-to-end latency by MIME type
+- p50/p95 by winning engine
+- fallback rate and failure rate by MIME
+
+Validation rule:
+
+- Speculation is confirmed when non-PDF p95 is **>=30%** above PDF p95 for comparable traffic windows.
+
+## Rollout plan
+
+1. **Phase 1 (`phased`):** new dispatcher active with Sumatra emergency fallback.
+2. **Phase 2 (`new-only`):** disable Sumatra fallback after stability and KPI review.
+3. **Phase 3:** remove Sumatra adapter, binary dependency docs, and legacy branching.
+
+Rollback path: switch `PRINT_DISPATCH_MODE=legacy`.
+
+## Test strategy
+
+- Unit tests for routing matrix and fallback sequencing.
+- Adapter command-construction tests (flags, quoting, options mapping).
+- Integration tests with mocked process runner for success/failure/timeout paths.
+- Operational validation on Windows kiosk:
+  - PDF dispatch/copies
+  - DOCX/XLSX/PPTX dispatch via LibreOffice
+  - JPG/PNG dispatch via LibreOffice
+  - forced primary failure to verify fallback and error propagation
+- Telemetry verification for p50/p95 and fallback metrics.
+
+## Risks and mitigations
+
+- **LibreOffice cold start latency:** warm-up at startup and explicit timeout handling.
+- **Binary path drift on kiosk hosts:** startup checks + explicit diagnostics.
+- **Option mismatch across engines:** centralized option normalization and adapter-specific mapping tests.
+- **Operational confidence during migration:** feature-flagged rollout and temporary Sumatra safety net.
+

--- a/esp32-captive-portal.ino
+++ b/esp32-captive-portal.ino
@@ -16,6 +16,7 @@ const char* fallbackKioskPortalPath = "/portal";
 const char* kioskRegisterToken = "printbit-register-token";
 const char* coinBridgeSource = "esp32";
 const char* coinBridgeApiKey = "printbit-coin-bridge-key";
+const char* hopperControlToken = "printbit-coin-bridge-key";
 
 NetworkServer server(80);
 
@@ -34,6 +35,7 @@ volatile unsigned long lastPulseMillis = 0;
 const unsigned long debounceMicros = 3000;
 const unsigned long coinTimeout = 200;
 const int maxCoinSendAttempts = 3;
+const int maxDispenseCoins = 50;
 
 // HOPPER
 volatile int coinDispensed = 0;
@@ -44,12 +46,21 @@ const unsigned long hopperDebounce = 120;
 
 bool dispensing = false;
 bool dispenseDone = false;
+bool dispenseTimedOut = false;
+volatile bool dispenseProgressDirty = false;
+int lastProgressReported = -1;
 
 // SAFETY
 unsigned long hopperStartTime = 0;
 const unsigned long hopperMaxRunTime = 15000;
 
 unsigned long coinEventCounter = 0;
+String activeDispenseRequestId = "";
+String lastDispenseRequestId = "";
+String lastDispenseOutcome = "idle";
+String lastDispenseError = "";
+unsigned long lastDispenseFinishedAt = 0;
+String serialLineBuffer = "";
 
 String decodeUrlComponent(const String& value) {
   String decoded = "";
@@ -87,6 +98,28 @@ String getFormValue(const String& body, const String& key) {
   int end = body.indexOf('&', start);
   if (end < 0) end = body.length();
   return decodeUrlComponent(body.substring(start, end));
+}
+
+String getQueryValue(const String& query, const String& key) {
+  String needle = key + "=";
+  int start = query.indexOf(needle);
+  if (start < 0) return "";
+  start += needle.length();
+  int end = query.indexOf('&', start);
+  if (end < 0) end = query.length();
+  return decodeUrlComponent(query.substring(start, end));
+}
+
+bool isNumericString(const String& value) {
+  if (value.length() == 0) return false;
+  for (size_t i = 0; i < value.length(); i++) {
+    if (!isDigit(value.charAt(i))) return false;
+  }
+  return true;
+}
+
+String buildHopperRequestId() {
+  return String((uint32_t)esp_random(), HEX) + "-" + String(millis());
 }
 
 String normalizedPath(const String& pathCandidate) {
@@ -187,6 +220,42 @@ void logCoinSendFailure(const String& classification, int code, const String& bo
   if (body.length() > 0) {
     Serial.print(":body=");
     Serial.print(body);
+  }
+  Serial.println();
+}
+
+void emitHopperAck(const String& requestId) {
+  Serial.print("HOPPER ACK ");
+  Serial.println(requestId);
+}
+
+void emitHopperProgress(const String& requestId, int dispensed, int total) {
+  Serial.print("HOPPER PROGRESS ");
+  Serial.print(requestId);
+  Serial.print(" ");
+  Serial.print(dispensed);
+  Serial.print(" ");
+  Serial.println(total);
+}
+
+void emitHopperDone(const String& requestId, int dispensedCount) {
+  Serial.print("HOPPER DONE ");
+  Serial.print(requestId);
+  Serial.print(" ");
+  Serial.println(dispensedCount);
+}
+
+void emitHopperError(
+    const String& requestId,
+    const String& errorCode,
+    const String& detail) {
+  Serial.print("HOPPER ERR ");
+  Serial.print(requestId.length() > 0 ? requestId : "n/a");
+  Serial.print(" ");
+  Serial.print(errorCode);
+  if (detail.length() > 0) {
+    Serial.print(" ");
+    Serial.print(detail);
   }
   Serial.println();
 }
@@ -308,7 +377,16 @@ void handleWifiRequest(NetworkClient& client) {
     return;
   }
 
+  String routePath = path;
+  String query = "";
+  int querySep = path.indexOf('?');
+  if (querySep >= 0) {
+    routePath = path.substring(0, querySep);
+    query = path.substring(querySep + 1);
+  }
+
   int contentLength = 0;
+  String hopperTokenHeader = "";
   while (client.connected()) {
     String headerLine = client.readStringUntil('\r');
     client.readStringUntil('\n');
@@ -321,30 +399,107 @@ void handleWifiRequest(NetworkClient& client) {
       String lengthPart = headerLine.substring(colonPos + 1);
       lengthPart.trim();
       contentLength = lengthPart.toInt();
+    } else if (headerKey == "x-hopper-token") {
+      hopperTokenHeader = headerLine.substring(colonPos + 1);
+      hopperTokenHeader.trim();
     }
   }
 
-  if (method == "POST" && path.startsWith("/kiosk/register")) {
+  String body = "";
+  if (contentLength > 0 && contentLength <= 512) {
+    body = readRequestBody(client, contentLength);
+  }
+
+  if (method == "POST" && routePath.startsWith("/kiosk/register")) {
     if (contentLength <= 0 || contentLength > 512) {
       replyPlain(client, 413, "Payload Too Large", "Invalid payload size");
       client.stop();
       return;
     }
-    String body = readRequestBody(client, contentLength);
     handleRegisterRequest(client, body);
     client.stop();
     return;
   }
 
-  if (method == "GET" && isCaptiveProbePath(path)) {
+  if (method == "GET" && isCaptiveProbePath(routePath)) {
     replyRedirect(client, kioskPortalUrl);
     client.stop();
     return;
   }
 
-  if (method == "GET" && path.startsWith("/?coins=")) {
-    int coins = path.substring(8).toInt();
-    startDispense(coins);
+  if ((method == "POST" || method == "GET") && routePath == "/hopper/dispense") {
+    String postedToken = getFormValue(body, "token");
+    String postedCoins = getFormValue(body, "coins");
+    String postedRequestId = getFormValue(body, "requestId");
+    if (postedToken.length() == 0) postedToken = hopperTokenHeader;
+    if (postedToken.length() == 0) postedToken = getQueryValue(query, "token");
+    if (postedCoins.length() == 0) postedCoins = getQueryValue(query, "coins");
+    if (postedRequestId.length() == 0) postedRequestId = getQueryValue(query, "requestId");
+
+    if (postedToken.length() == 0 || postedToken != hopperControlToken) {
+      replyPlain(client, 401, "Unauthorized", "Invalid hopper token");
+      Serial.println("hopper_dispense_rejected:unauthorized");
+      client.stop();
+      return;
+    }
+    if (!isNumericString(postedCoins)) {
+      replyPlain(client, 400, "Bad Request", "Missing or invalid coins");
+      Serial.println("hopper_dispense_rejected:invalid_coins");
+      client.stop();
+      return;
+    }
+
+    int coins = postedCoins.toInt();
+    String requestId = postedRequestId.length() > 0 ? postedRequestId : buildHopperRequestId();
+    if (!startDispense(coins, requestId, "http")) {
+      replyPlain(client, 409, "Conflict", "Dispense busy or invalid");
+      client.stop();
+      return;
+    }
+    replyPlain(client, 202, "Accepted", "hopper_dispense_started");
+    client.stop();
+    return;
+  }
+
+  if (method == "GET" && routePath == "/hopper/status") {
+    String providedToken = getQueryValue(query, "token");
+    if (providedToken.length() == 0) providedToken = hopperTokenHeader;
+    if (providedToken.length() == 0 || providedToken != hopperControlToken) {
+      replyPlain(client, 401, "Unauthorized", "Invalid hopper token");
+      client.stop();
+      return;
+    }
+    int dispensedSnapshot = 0;
+    noInterrupts();
+    dispensedSnapshot = coinDispensed;
+    interrupts();
+
+    String response = "{";
+    response += "\"dispensing\":";
+    response += dispensing ? "true" : "false";
+    response += ",\"targetCoins\":";
+    response += String(targetCoins);
+    response += ",\"dispensedCoins\":";
+    response += String(dispensedSnapshot);
+    response += ",\"activeRequestId\":\"";
+    response += activeDispenseRequestId;
+    response += "\",\"lastRequestId\":\"";
+    response += lastDispenseRequestId;
+    response += "\",\"lastOutcome\":\"";
+    response += lastDispenseOutcome;
+    response += "\",\"lastError\":\"";
+    response += lastDispenseError;
+    response += "\",\"lastFinishedAtMs\":";
+    response += String(lastDispenseFinishedAt);
+    response += "}";
+    replyPlain(client, 200, "OK", response);
+    client.stop();
+    return;
+  }
+
+  if (method == "GET" && routePath == "/" && query.startsWith("coins=")) {
+    int coins = getQueryValue(query, "coins").toInt();
+    startDispense(coins, buildHopperRequestId(), "legacy_query");
   }
 
   replyPlain(client, 200, "OK", "PRINTBIT OK");
@@ -367,6 +522,7 @@ void IRAM_ATTR coinDetected() {
 
   if (now - lastCoinTime > hopperDebounce) {
     coinDispensed++;
+    dispenseProgressDirty = true;
     lastCoinTime = now;
 
     if (dispensing && coinDispensed >= targetCoins) {
@@ -378,20 +534,94 @@ void IRAM_ATTR coinDetected() {
 }
 
 // DISPENSE
-void startDispense(int coins) {
-  if (dispensing) return;
-  if (coins <= 0 || coins > 50) return;
+bool startDispense(
+    int coins,
+    const String& requestId,
+    const String& sourceLabel) {
+  if (dispensing) {
+    emitHopperError(requestId, "UNKNOWN", "BUSY");
+    return false;
+  }
+  if (coins <= 0 || coins > maxDispenseCoins) {
+    emitHopperError(requestId, "UNKNOWN", "INVALID_COIN_COUNT");
+    return false;
+  }
 
   targetCoins = coins;
+  noInterrupts();
   coinDispensed = 0;
+  dispenseProgressDirty = false;
+  interrupts();
   dispensing = true;
   dispenseDone = false;
+  dispenseTimedOut = false;
   hopperStartTime = millis();
+  lastProgressReported = -1;
+  activeDispenseRequestId = requestId.length() > 0 ? requestId : buildHopperRequestId();
+  lastDispenseRequestId = activeDispenseRequestId;
+  lastDispenseOutcome = "dispensing";
+  lastDispenseError = "";
 
   digitalWrite(relayPin, HIGH);
+  emitHopperAck(activeDispenseRequestId);
 
-  Serial.print("START ");
-  Serial.println(targetCoins);
+  Serial.print("hopper_start:requestId=");
+  Serial.print(activeDispenseRequestId);
+  Serial.print(":coins=");
+  Serial.print(targetCoins);
+  Serial.print(":source=");
+  Serial.println(sourceLabel);
+  return true;
+}
+
+void handleSerialCommand(const String& rawLine) {
+  String line = rawLine;
+  line.trim();
+  if (line.length() == 0) return;
+
+  if (line.startsWith("HOPPER ")) {
+    int first = line.indexOf(' ');
+    int second = line.indexOf(' ', first + 1);
+    String verb = second > 0 ? line.substring(first + 1, second) : "";
+    verb.toUpperCase();
+
+    if (verb == "SELFTEST") {
+      String requestId =
+          second > 0 ? line.substring(second + 1) : buildHopperRequestId();
+      requestId.trim();
+      if (requestId.length() == 0) requestId = buildHopperRequestId();
+      emitHopperAck(requestId);
+      emitHopperDone(requestId, 0);
+      return;
+    }
+
+    if (verb == "DISPENSE") {
+      int third = line.indexOf(' ', second + 1);
+      String requestId = third > 0 ? line.substring(second + 1, third) : "";
+      String coinsRaw = third > 0 ? line.substring(third + 1) : "";
+      requestId.trim();
+      coinsRaw.trim();
+      if (requestId.length() == 0) requestId = buildHopperRequestId();
+      if (!isNumericString(coinsRaw)) {
+        emitHopperError(requestId, "UNKNOWN", "INVALID_COIN_COUNT");
+        return;
+      }
+
+      int coins = coinsRaw.toInt();
+      startDispense(coins, requestId, "serial_protocol");
+      return;
+    }
+
+    emitHopperError(buildHopperRequestId(), "UNKNOWN", "UNSUPPORTED_COMMAND");
+    return;
+  }
+
+  if (isNumericString(line)) {
+    int command = line.toInt();
+    if (command > 0 && command <= maxDispenseCoins) {
+      startDispense(command, buildHopperRequestId(), "serial_legacy");
+    }
+  }
 }
 
 // SETUP
@@ -454,10 +684,16 @@ void loop() {
   }
 
   // SERIAL COMMAND
-  if (Serial.available()) {
-    int command = Serial.parseInt();
-    if (command > 0 && command <= 50) {
-      startDispense(command);
+  while (Serial.available()) {
+    char c = char(Serial.read());
+    if (c == '\r') continue;
+    if (c == '\n') {
+      handleSerialCommand(serialLineBuffer);
+      serialLineBuffer = "";
+      continue;
+    }
+    if (serialLineBuffer.length() < 120) {
+      serialLineBuffer += c;
     }
   }
 
@@ -467,17 +703,49 @@ void loop() {
     handleWifiRequest(client);
   }
 
+  int dispensedSnapshot = 0;
+  bool progressDirtySnapshot = false;
+  noInterrupts();
+  dispensedSnapshot = coinDispensed;
+  progressDirtySnapshot = dispenseProgressDirty;
+  dispenseProgressDirty = false;
+  interrupts();
+
+  if (dispensing && progressDirtySnapshot && dispensedSnapshot != lastProgressReported) {
+    lastProgressReported = dispensedSnapshot;
+    emitHopperProgress(activeDispenseRequestId, dispensedSnapshot, targetCoins);
+  }
+
   // HOPPER TIMEOUT
   if (dispensing && millis() - hopperStartTime > hopperMaxRunTime) {
-    Serial.println("HOPPER TIMEOUT");
     digitalWrite(relayPin, LOW);
     dispensing = false;
-    dispenseDone = true;
+    dispenseTimedOut = true;
+  }
+
+  if (dispenseTimedOut) {
+    dispenseTimedOut = false;
+    lastDispenseOutcome = "failed";
+    lastDispenseError = "MOTOR_TIMEOUT";
+    lastDispenseFinishedAt = millis();
+    emitHopperError(activeDispenseRequestId, "MOTOR_TIMEOUT", "timeout");
+    Serial.print("hopper_done:requestId=");
+    Serial.print(activeDispenseRequestId);
+    Serial.println(":outcome=failed");
+    activeDispenseRequestId = "";
   }
 
   if (dispenseDone) {
-    Serial.println("DONE");
     dispenseDone = false;
+    lastDispenseOutcome = "done";
+    lastDispenseError = "";
+    lastDispenseFinishedAt = millis();
+    emitHopperDone(lastDispenseRequestId, dispensedSnapshot);
+    Serial.print("hopper_done:requestId=");
+    Serial.print(lastDispenseRequestId);
+    Serial.print(":dispensed=");
+    Serial.println(dispensedSnapshot);
+    activeDispenseRequestId = "";
   }
 
   static unsigned long lastRegistrationStatusAt = 0;

--- a/src/config/http.config.ts
+++ b/src/config/http.config.ts
@@ -115,6 +115,74 @@ export const SESSION_EXPIRY_ENABLED =
     ? true
     : !SESSION_EXPIRY_DISABLED_TOKENS.has(rawSessionExpiryEnabled);
 
+export type PrintDispatchMode = 'legacy' | 'phased' | 'new-only';
+
+function readPathEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function readPositiveIntEnv(
+  value: string | undefined,
+  fallback: number,
+  minimum = 1,
+): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  const normalized = Math.floor(parsed);
+  return normalized >= minimum ? normalized : fallback;
+}
+
+const rawPrintDispatchMode = (
+  process.env.PRINTBIT_PRINT_DISPATCH_MODE ??
+  process.env.PRINT_DISPATCH_MODE ??
+  'legacy'
+)
+  .trim()
+  .toLowerCase();
+
+export const PRINT_DISPATCH_MODE: PrintDispatchMode =
+  rawPrintDispatchMode === 'phased' || rawPrintDispatchMode === 'new-only'
+    ? rawPrintDispatchMode
+    : 'legacy';
+
+export const SUMATRA_PATH =
+  readPathEnv('PRINTBIT_SUMATRA_PATH', 'SUMATRA_PATH') ??
+  path.resolve('bin', 'SumatraPDF.exe');
+
+export const PDFTOPRINTER_PATH =
+  readPathEnv(
+    'PRINTBIT_PDFTOPRINTER_PATH',
+    'PDFTOPRINTER_PATH',
+    'PDFTTOPRINTER_PATH',
+  ) ?? path.resolve('bin', 'PDFtoPrinter.exe');
+
+export const GHOSTSCRIPT_PATH = readPathEnv(
+  'PRINTBIT_GHOSTSCRIPT_PATH',
+  'GHOSTSCRIPT_PATH',
+);
+
+export const LIBREOFFICE_PATH = readPathEnv(
+  'PRINTBIT_LIBREOFFICE_PATH',
+  'LIBREOFFICE_PATH',
+);
+
+export const PRINT_DISPATCH_TIMEOUT_MS = readPositiveIntEnv(
+  process.env.PRINTBIT_PRINT_DISPATCH_TIMEOUT_MS?.trim(),
+  60_000,
+  5_000,
+);
+
+export const PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS = readPositiveIntEnv(
+  process.env.PRINTBIT_PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS?.trim(),
+  120_000,
+  10_000,
+);
+
 export const PUBLIC_PAGE_ROUTES: Array<{ route: string; filePath: string }> = [
   { route: '/', filePath: path.join(PUBLIC_DIR, 'index.html') },
   { route: '/print', filePath: path.join(PUBLIC_DIR, 'print', 'index.html') },

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '@/services/printer-status';
 import { getExternalWatchdogState } from '@/services/watchdog-health';
 import { detectDefaultPrinter, printFile } from '@/services/printer';
+import { PrintDispatchError } from '@/services/print-dispatcher';
 import { getScannerStatus } from '@/services/scanner';
 import {
   getTrustedTimeStatus,
@@ -368,6 +369,12 @@ export class AdminController {
       requireAdminLocalAccess,
       requireAdminPin,
       this.handleGetEarningsAnalytics,
+    );
+    this.router.get(
+      '/print-dispatch/latency',
+      requireAdminLocalAccess,
+      requireAdminPin,
+      this.handleGetPrintDispatchLatency,
     );
     this.router.get(
       '/system/time-sync',
@@ -774,6 +781,14 @@ export class AdminController {
     });
 
     return res.json(analytics);
+  };
+
+  private handleGetPrintDispatchLatency = (req: Request, res: Response) => {
+    const maxEventsRaw =
+      typeof req.query.maxEvents === 'string' ? req.query.maxEvents : undefined;
+    const maxEvents = maxEventsRaw ? Number(maxEventsRaw) : 5000;
+    const metrics = this.adminService.computeDispatchLatencyMetrics(maxEvents);
+    return res.json(metrics);
   };
 
   private handleGetTimeSync = async (_req: Request, res: Response) => {
@@ -1296,6 +1311,7 @@ export class AdminController {
 
   private handleTestPrint = async (_req: Request, res: Response) => {
     const telemetry = getPrinterTelemetry();
+    const startedAtMs = Date.now();
 
     if (!telemetry.connected || !telemetry.name) {
       await this.adminService.appendAdminLog(
@@ -1317,12 +1333,21 @@ export class AdminController {
       const pdfBuffer = generateTestPagePdf(new Date());
       fs.writeFileSync(tmpAbsPath, pdfBuffer);
 
-      await printFile(tmpFilename, {
-        copies: 1,
-        colorMode: 'grayscale',
-        orientation: 'portrait',
-        paperSize: 'A4',
-      });
+      const dispatchResult = await printFile(
+        tmpFilename,
+        {
+          copies: 1,
+          colorMode: 'grayscale',
+          orientation: 'portrait',
+          paperSize: 'A4',
+          printerName: telemetry.name,
+        },
+        {
+          mode: 'admin-test',
+          source: 'admin-test-print',
+        },
+      );
+      const totalElapsedMs = Date.now() - startedAtMs;
 
       await this.adminService.appendAdminLog(
         'admin_test_print',
@@ -1332,6 +1357,27 @@ export class AdminController {
           printerStatus: telemetry.status,
           driverName: telemetry.driverName ?? null,
           portName: telemetry.portName ?? null,
+          totalElapsedMs,
+          dispatchDurationMs: dispatchResult.durationMs,
+          dispatchEngine: dispatchResult.selectedEngine ?? null,
+          dispatchAttempts: dispatchResult.attempts.length,
+          dispatchMode: dispatchResult.mode,
+          dispatchRequestedMode: dispatchResult.requestedMode,
+        },
+      );
+      await this.adminService.appendAdminLog(
+        'admin_test_print_timing',
+        `Admin test print timing recorded for "${telemetry.name}".`,
+        {
+          printerName: telemetry.name,
+          totalElapsedMs,
+          dispatchDurationMs: dispatchResult.durationMs,
+          dispatchEngine: dispatchResult.selectedEngine ?? null,
+          dispatchAttempts: dispatchResult.attempts.length,
+          dispatchMode: dispatchResult.mode,
+          dispatchRequestedMode: dispatchResult.requestedMode,
+          dispatchMimeType: dispatchResult.mimeType,
+          dispatchExtension: dispatchResult.fileExtension,
         },
       );
 
@@ -1340,21 +1386,42 @@ export class AdminController {
         printerName: telemetry.name,
         printerStatus: telemetry.status,
         message: `Test page sent to "${telemetry.name}". Check the printer output tray.`,
+        timing: {
+          totalElapsedMs,
+          dispatchDurationMs: dispatchResult.durationMs,
+          dispatchEngine: dispatchResult.selectedEngine,
+          dispatchAttempts: dispatchResult.attempts.length,
+        },
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
+      const totalElapsedMs = Date.now() - startedAtMs;
+      const dispatchFailure =
+        err instanceof PrintDispatchError ? err.result : null;
       await this.adminService.appendAdminLog(
         'admin_test_print_failed',
         `Admin test print failed on "${telemetry.name}".`,
         {
           printerName: telemetry.name,
           error: message,
+          totalElapsedMs,
+          dispatchDurationMs: dispatchFailure?.durationMs ?? null,
+          dispatchEngine: dispatchFailure?.selectedEngine ?? null,
+          dispatchAttempts: dispatchFailure?.attempts.length ?? null,
+          dispatchMode: dispatchFailure?.mode ?? null,
+          dispatchRequestedMode: dispatchFailure?.requestedMode ?? null,
         },
       );
       res.status(500).json({
         ok: false,
         error: message,
         printerName: telemetry.name,
+        timing: {
+          totalElapsedMs,
+          dispatchDurationMs: dispatchFailure?.durationMs ?? null,
+          dispatchEngine: dispatchFailure?.selectedEngine ?? null,
+          dispatchAttempts: dispatchFailure?.attempts.length ?? null,
+        },
       });
     } finally {
       try {

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -49,6 +49,35 @@ export interface EarningsAnalyticsResult {
   };
 }
 
+export interface DispatchLatencyPercentiles {
+  p50: number | null;
+  p95: number | null;
+  sampleCount: number;
+}
+
+export interface DispatchLatencyByMime extends DispatchLatencyPercentiles {
+  mimeType: string;
+}
+
+export interface DispatchLatencyByEngine extends DispatchLatencyPercentiles {
+  engine: string;
+}
+
+export interface DispatchLatencySpeculation {
+  baselinePdfP95: number | null;
+  worstNonPdfP95: number | null;
+  thresholdPercent: number;
+  confirmed: boolean;
+}
+
+export interface DispatchLatencyMetricsResult {
+  generatedAt: string;
+  sampleCount: number;
+  byMimeType: DispatchLatencyByMime[];
+  byEngine: DispatchLatencyByEngine[];
+  speculation: DispatchLatencySpeculation;
+}
+
 export class AdminService {
   private readonly MAX_LOGS = 3000;
 
@@ -515,6 +544,157 @@ export class AdminService {
         scan: normalizedMethods.scan,
         total: methodTotal,
         topMode,
+      },
+    };
+  }
+
+  private computePercentile(
+    values: number[],
+    percentile: number,
+  ): number | null {
+    if (values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    if (sorted.length === 1) return sorted[0];
+    const index = (percentile / 100) * (sorted.length - 1);
+    const lower = Math.floor(index);
+    const upper = Math.ceil(index);
+    if (lower === upper) return sorted[lower];
+    const weight = index - lower;
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * weight;
+  }
+
+  private summarizeLatencies(values: number[]): DispatchLatencyPercentiles {
+    const p50 = this.computePercentile(values, 50);
+    const p95 = this.computePercentile(values, 95);
+    return {
+      p50: p50 === null ? null : Math.round(p50),
+      p95: p95 === null ? null : Math.round(p95),
+      sampleCount: values.length,
+    };
+  }
+
+  computeDispatchLatencyMetrics(maxEvents = 5000): DispatchLatencyMetricsResult {
+    const safeMaxEvents = Number.isFinite(maxEvents)
+      ? Math.max(100, Math.min(20_000, Math.floor(maxEvents)))
+      : 5000;
+    const logs = adminLogStore
+      .listByTypes([
+        'print_dispatch_summary',
+        'print_spooler_confirmed',
+        'print_spooler_job_failed',
+        'print_spooler_auto_refund',
+        'print_spooler_monitor_timeout',
+        'print_spooler_monitor_unavailable',
+      ])
+      .slice(0, safeMaxEvents);
+
+    const dispatchByTransaction = new Map<
+      string,
+      {
+        dispatchedAtMs: number;
+        mimeType: string;
+        engine: string;
+      }
+    >();
+    const terminalByTransaction = new Map<string, number>();
+
+    for (const log of logs) {
+      const transactionId =
+        typeof log.meta?.transactionId === 'string'
+          ? log.meta.transactionId.trim()
+          : '';
+      if (!transactionId) continue;
+      const timestampMs = Date.parse(log.timestamp);
+      if (!Number.isFinite(timestampMs)) continue;
+
+      if (log.type === 'print_dispatch_summary') {
+        const engine =
+          typeof log.meta?.selectedEngine === 'string'
+            ? log.meta.selectedEngine
+            : null;
+        if (!engine) continue;
+        const mimeType =
+          typeof log.meta?.mimeType === 'string' && log.meta.mimeType.length > 0
+            ? log.meta.mimeType
+            : 'application/octet-stream';
+        const existing = dispatchByTransaction.get(transactionId);
+        if (!existing || timestampMs >= existing.dispatchedAtMs) {
+          dispatchByTransaction.set(transactionId, {
+            dispatchedAtMs: timestampMs,
+            mimeType,
+            engine,
+          });
+        }
+        continue;
+      }
+
+      const existingTerminal = terminalByTransaction.get(transactionId);
+      if (!existingTerminal || timestampMs >= existingTerminal) {
+        terminalByTransaction.set(transactionId, timestampMs);
+      }
+    }
+
+    const mimeSamples = new Map<string, number[]>();
+    const engineSamples = new Map<string, number[]>();
+
+    for (const [transactionId, dispatchMeta] of dispatchByTransaction.entries()) {
+      const terminalAtMs = terminalByTransaction.get(transactionId);
+      if (terminalAtMs === undefined || !Number.isFinite(terminalAtMs)) continue;
+      const latencyMs = terminalAtMs - dispatchMeta.dispatchedAtMs;
+      if (!Number.isFinite(latencyMs) || latencyMs < 0) continue;
+
+      const byMime = mimeSamples.get(dispatchMeta.mimeType) ?? [];
+      byMime.push(latencyMs);
+      mimeSamples.set(dispatchMeta.mimeType, byMime);
+
+      const byEngine = engineSamples.get(dispatchMeta.engine) ?? [];
+      byEngine.push(latencyMs);
+      engineSamples.set(dispatchMeta.engine, byEngine);
+    }
+
+    const byMimeType = Array.from(mimeSamples.entries())
+      .map(([mimeType, values]) => ({
+        mimeType,
+        ...this.summarizeLatencies(values),
+      }))
+      .sort((a, b) => b.sampleCount - a.sampleCount);
+
+    const byEngine = Array.from(engineSamples.entries())
+      .map(([engine, values]) => ({
+        engine,
+        ...this.summarizeLatencies(values),
+      }))
+      .sort((a, b) => b.sampleCount - a.sampleCount);
+
+    const pdfBucket = byMimeType.find(
+      (bucket) => bucket.mimeType === 'application/pdf',
+    );
+    const nonPdfP95Values = byMimeType
+      .filter((bucket) => bucket.mimeType !== 'application/pdf')
+      .map((bucket) => bucket.p95)
+      .filter((value): value is number => value !== null);
+    const worstNonPdfP95 =
+      nonPdfP95Values.length > 0 ? Math.max(...nonPdfP95Values) : null;
+    const thresholdPercent = 30;
+    const baselinePdfP95 = pdfBucket?.p95 ?? null;
+    const confirmed =
+      baselinePdfP95 !== null &&
+      worstNonPdfP95 !== null &&
+      worstNonPdfP95 >= baselinePdfP95 * (1 + thresholdPercent / 100);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      sampleCount: Array.from(mimeSamples.values()).reduce(
+        (sum, values) => sum + values.length,
+        0,
+      ),
+      byMimeType,
+      byEngine,
+      speculation: {
+        baselinePdfP95,
+        worstNonPdfP95,
+        thresholdPercent,
+        confirmed,
       },
     };
   }

--- a/src/modules/copy/copy.service.ts
+++ b/src/modules/copy/copy.service.ts
@@ -462,6 +462,7 @@ export class CopyService {
           colorMode: normalized.colorMode,
           orientation: normalized.orientation,
           paperSize: normalized.paperSize,
+          printerName: telemetry.name ?? undefined,
         };
         const relPath = path.join('scans', previewFilename);
         await financialLedgerService.append({
@@ -475,7 +476,11 @@ export class CopyService {
             previewFilename,
           },
         });
-        await printFile(relPath, printOptions);
+        await printFile(relPath, printOptions, {
+          transactionId: jobId,
+          mode: 'copy',
+          source: 'copy-service',
+        });
 
         void watchJobForMalfunction(this.deps.io, {
           jobId,

--- a/src/modules/financial/financial.service.ts
+++ b/src/modules/financial/financial.service.ts
@@ -1521,6 +1521,7 @@ export class FinancialService {
         : getPrinterTelemetry();
     let jobDispatchedAt: string | null = null;
     let dispatchResult: PrintDispatchResult | null = null;
+    let spoolerMonitorStarted = false;
 
     if (mode === 'print' && serverFilename && printOptions) {
       if (!telemetry.connected || BLOCKED_STATUSES.has(telemetry.status)) {
@@ -1609,6 +1610,59 @@ export class FinancialService {
             dispatchAttempts: dispatchResult.attempts.length,
           },
         });
+        if (jobDispatchedAt && telemetry.name) {
+          spoolerMonitorStarted = true;
+          void monitorSpoolerJob({
+            printerName: telemetry.name,
+            chargedAmount: requiredAmount,
+            jobDispatchedAt,
+            spoolerCorrelationKey,
+            io: this.deps.io,
+            jobContext: {
+              transactionId,
+              mode,
+              copies,
+              colorMode: printOptions?.colorMode ?? colorMode,
+              duplex: printOptions?.duplex ?? false,
+              spoolerCorrelationKey,
+              sessionId: sessionId ?? null,
+              documentId: targetDocumentId ?? null,
+              filename: serverFilename ?? null,
+              pageRange: printOptions?.pageRange ?? null,
+              dispatchEngine: dispatchResult?.selectedEngine ?? null,
+              dispatchMode: dispatchResult?.mode ?? null,
+              dispatchRequestedMode: dispatchResult?.requestedMode ?? null,
+              dispatchDurationMs: dispatchResult?.durationMs ?? null,
+              dispatchMimeType: dispatchResult?.mimeType ?? null,
+              dispatchExtension: dispatchResult?.fileExtension ?? null,
+              dispatchAttempts: dispatchResult?.attempts.length ?? null,
+              monitorStartPhase: 'post_dispatch',
+            },
+            onConfirmed: async () => {
+              try {
+                appendConsumableUsageEvent('print');
+                await evaluateConsumablesForecastAlerts();
+              } catch (error) {
+                console.error(
+                  '[CONFIRM-PAYMENT] Failed to persist print consumable usage event.',
+                  error instanceof Error ? error.message : error,
+                );
+              }
+              if (!serverFilename) return;
+              await this.cleanupPrintUploadAfterSpoolerSuccess({
+                transactionId,
+                sessionId: sessionId ?? null,
+                documentId: targetDocumentId ?? null,
+                filename: serverFilename,
+              });
+            },
+          }).catch((err) => {
+            console.error(
+              '[SPOOLER-MONITOR] monitorSpoolerJob failed:',
+              err instanceof Error ? err.message : err,
+            );
+          });
+        }
       } catch (err) {
         const dispatchFailure =
           err instanceof PrintDispatchError ? err.result : null;
@@ -1902,8 +1956,27 @@ export class FinancialService {
       }
     })();
 
-    if (mode === 'print' && jobDispatchedAt) {
-      if (telemetry.name) {
+    if (mode === 'print' && jobDispatchedAt && !spoolerMonitorStarted) {
+      if (!telemetry.name) {
+        void this.handleMissingSpoolerTelemetry({
+          transactionId,
+          chargedAmount: settledAmount,
+          spoolerCorrelationKey,
+          sessionId: sessionId ?? null,
+          documentId: targetDocumentId ?? null,
+          filename: serverFilename ?? null,
+          copies,
+          colorMode: printOptions?.colorMode ?? colorMode,
+          duplex: printOptions?.duplex ?? false,
+          pageRange: printOptions?.pageRange ?? null,
+          jobDispatchedAt,
+        }).catch((error) => {
+          console.error(
+            '[CONFIRM-PAYMENT] Missing telemetry fallback failed:',
+            error instanceof Error ? error.message : error,
+          );
+        });
+      } else {
         void monitorSpoolerJob({
           printerName: telemetry.name,
           chargedAmount: settledAmount,
@@ -1928,6 +2001,7 @@ export class FinancialService {
             dispatchMimeType: dispatchResult?.mimeType ?? null,
             dispatchExtension: dispatchResult?.fileExtension ?? null,
             dispatchAttempts: dispatchResult?.attempts.length ?? null,
+            monitorStartPhase: 'post_settlement_fallback',
           },
           onConfirmed: async () => {
             try {
@@ -1951,25 +2025,6 @@ export class FinancialService {
           console.error(
             '[SPOOLER-MONITOR] monitorSpoolerJob failed:',
             err instanceof Error ? err.message : err,
-          );
-        });
-      } else {
-        void this.handleMissingSpoolerTelemetry({
-          transactionId,
-          chargedAmount: settledAmount,
-          spoolerCorrelationKey,
-          sessionId: sessionId ?? null,
-          documentId: targetDocumentId ?? null,
-          filename: serverFilename ?? null,
-          copies,
-          colorMode: printOptions?.colorMode ?? colorMode,
-          duplex: printOptions?.duplex ?? false,
-          pageRange: printOptions?.pageRange ?? null,
-          jobDispatchedAt,
-        }).catch((error) => {
-          console.error(
-            '[CONFIRM-PAYMENT] Missing telemetry fallback failed:',
-            error instanceof Error ? error.message : error,
           );
         });
       }

--- a/src/modules/financial/financial.service.ts
+++ b/src/modules/financial/financial.service.ts
@@ -1522,6 +1522,7 @@ export class FinancialService {
     let jobDispatchedAt: string | null = null;
     let dispatchResult: PrintDispatchResult | null = null;
     let spoolerMonitorStarted = false;
+    let settlementCompleted = false;
 
     if (mode === 'print' && serverFilename && printOptions) {
       if (!telemetry.connected || BLOCKED_STATUSES.has(telemetry.status)) {
@@ -1610,59 +1611,6 @@ export class FinancialService {
             dispatchAttempts: dispatchResult.attempts.length,
           },
         });
-        if (jobDispatchedAt && telemetry.name) {
-          spoolerMonitorStarted = true;
-          void monitorSpoolerJob({
-            printerName: telemetry.name,
-            chargedAmount: requiredAmount,
-            jobDispatchedAt,
-            spoolerCorrelationKey,
-            io: this.deps.io,
-            jobContext: {
-              transactionId,
-              mode,
-              copies,
-              colorMode: printOptions?.colorMode ?? colorMode,
-              duplex: printOptions?.duplex ?? false,
-              spoolerCorrelationKey,
-              sessionId: sessionId ?? null,
-              documentId: targetDocumentId ?? null,
-              filename: serverFilename ?? null,
-              pageRange: printOptions?.pageRange ?? null,
-              dispatchEngine: dispatchResult?.selectedEngine ?? null,
-              dispatchMode: dispatchResult?.mode ?? null,
-              dispatchRequestedMode: dispatchResult?.requestedMode ?? null,
-              dispatchDurationMs: dispatchResult?.durationMs ?? null,
-              dispatchMimeType: dispatchResult?.mimeType ?? null,
-              dispatchExtension: dispatchResult?.fileExtension ?? null,
-              dispatchAttempts: dispatchResult?.attempts.length ?? null,
-              monitorStartPhase: 'post_dispatch',
-            },
-            onConfirmed: async () => {
-              try {
-                appendConsumableUsageEvent('print');
-                await evaluateConsumablesForecastAlerts();
-              } catch (error) {
-                console.error(
-                  '[CONFIRM-PAYMENT] Failed to persist print consumable usage event.',
-                  error instanceof Error ? error.message : error,
-                );
-              }
-              if (!serverFilename) return;
-              await this.cleanupPrintUploadAfterSpoolerSuccess({
-                transactionId,
-                sessionId: sessionId ?? null,
-                documentId: targetDocumentId ?? null,
-                filename: serverFilename,
-              });
-            },
-          }).catch((err) => {
-            console.error(
-              '[SPOOLER-MONITOR] monitorSpoolerJob failed:',
-              err instanceof Error ? err.message : err,
-            );
-          });
-        }
       } catch (err) {
         const dispatchFailure =
           err instanceof PrintDispatchError ? err.result : null;
@@ -1755,6 +1703,7 @@ export class FinancialService {
       });
       return;
     }
+    settlementCompleted = true;
 
     await checkpointRecoverySession({
       transactionId,
@@ -1977,6 +1926,7 @@ export class FinancialService {
           );
         });
       } else {
+        spoolerMonitorStarted = true;
         void monitorSpoolerJob({
           printerName: telemetry.name,
           chargedAmount: settledAmount,
@@ -2001,9 +1951,16 @@ export class FinancialService {
             dispatchMimeType: dispatchResult?.mimeType ?? null,
             dispatchExtension: dispatchResult?.fileExtension ?? null,
             dispatchAttempts: dispatchResult?.attempts.length ?? null,
-            monitorStartPhase: 'post_settlement_fallback',
+            monitorStartPhase: 'post_settlement',
           },
           onConfirmed: async () => {
+            if (!settlementCompleted) {
+              console.warn(
+                '[SPOOLER-MONITOR] Skipping post-confirmed callbacks because settlement did not complete.',
+                { transactionId, spoolerCorrelationKey },
+              );
+              return;
+            }
             try {
               appendConsumableUsageEvent('print');
               await evaluateConsumablesForecastAlerts();

--- a/src/modules/financial/financial.service.ts
+++ b/src/modules/financial/financial.service.ts
@@ -36,7 +36,11 @@ import {
 import { adminService } from '@/services/admin';
 import { financialLedgerService } from '@/services/financial-ledger';
 import { settlementService } from '@/services/settlement';
-import { printFile, type PrintJobOptions } from '@/services/printer';
+import {
+  printFile,
+  type PrintDispatchResult,
+  type PrintJobOptions,
+} from '@/services/printer';
 import { monitorSpoolerJob } from '@/services/print-spooler';
 import { persistAndEmitPrintLifecycleState } from '@/services/print-lifecycle-state';
 import type { SessionStore, UploadedDocument } from '@/services/session';
@@ -58,6 +62,7 @@ import {
   upsertSpoolerFailureRefund,
 } from '@/services/pending-refund';
 import { evaluateConsumablesForecastAlerts } from '@/modules/admin/consumables.service';
+import { PrintDispatchError } from '@/services/print-dispatcher';
 
 export interface FinancialServiceDeps {
   io: Server;
@@ -1114,7 +1119,17 @@ export class FinancialService {
     }
 
     try {
-      await printFile(filename, defaultOptions);
+      await printFile(
+        filename,
+        {
+          ...defaultOptions,
+          printerName: legacyTelemetry.name ?? undefined,
+        },
+        {
+          mode: 'legacy-print',
+          source: 'legacy-print-route',
+        },
+      );
     } catch (err) {
       void adminService.appendAdminLog(
         'print_failed',
@@ -1505,6 +1520,7 @@ export class FinancialService {
         ? await refreshPrinterTelemetry()
         : getPrinterTelemetry();
     let jobDispatchedAt: string | null = null;
+    let dispatchResult: PrintDispatchResult | null = null;
 
     if (mode === 'print' && serverFilename && printOptions) {
       if (!telemetry.connected || BLOCKED_STATUSES.has(telemetry.status)) {
@@ -1559,7 +1575,18 @@ export class FinancialService {
 
       try {
         jobDispatchedAt = getTrustedTimestamp().timestamp;
-        await printFile(serverFilename, printOptions);
+        const dispatchOptions: PrintJobOptions = {
+          ...printOptions,
+          printerName: telemetry.name ?? undefined,
+        };
+        dispatchResult = await printFile(serverFilename, dispatchOptions, {
+          transactionId,
+          sessionId: sessionId ?? null,
+          documentId: targetDocumentId ?? null,
+          spoolerCorrelationKey,
+          mode: 'print',
+          source: 'confirm-payment',
+        });
         await checkpointRecoverySession({
           transactionId,
           mode,
@@ -1573,9 +1600,18 @@ export class FinancialService {
           context: {
             filename: serverFilename,
             spoolerDispatched: true,
+            dispatchEngine: dispatchResult.selectedEngine ?? null,
+            dispatchMode: dispatchResult.mode,
+            dispatchRequestedMode: dispatchResult.requestedMode,
+            dispatchDurationMs: dispatchResult.durationMs,
+            dispatchMimeType: dispatchResult.mimeType,
+            dispatchExtension: dispatchResult.fileExtension,
+            dispatchAttempts: dispatchResult.attempts.length,
           },
         });
       } catch (err) {
+        const dispatchFailure =
+          err instanceof PrintDispatchError ? err.result : null;
         await persistAndEmitPrintLifecycleState(
           this.deps.io,
           {
@@ -1592,6 +1628,13 @@ export class FinancialService {
             documentId: targetDocumentId ?? null,
             meta: {
               stage: 'dispatch',
+              dispatchEngine: dispatchFailure?.selectedEngine ?? null,
+              dispatchMode: dispatchFailure?.mode ?? null,
+              dispatchRequestedMode: dispatchFailure?.requestedMode ?? null,
+              dispatchDurationMs: dispatchFailure?.durationMs ?? null,
+              dispatchMimeType: dispatchFailure?.mimeType ?? null,
+              dispatchExtension: dispatchFailure?.fileExtension ?? null,
+              dispatchAttempts: dispatchFailure?.attempts.length ?? null,
             },
           },
         );
@@ -1768,6 +1811,10 @@ export class FinancialService {
               state: 'awaiting_spooler_terminal',
               spoolerCorrelationKey,
               jobDispatchedAt,
+              dispatchEngine: dispatchResult?.selectedEngine ?? null,
+              dispatchMode: dispatchResult?.mode ?? null,
+              dispatchRequestedMode: dispatchResult?.requestedMode ?? null,
+              dispatchDurationMs: dispatchResult?.durationMs ?? null,
             }
           : undefined,
     });
@@ -1808,6 +1855,13 @@ export class FinancialService {
           documentId: targetDocumentId ?? null,
           sessionId: sessionId ?? null,
           filename: serverFilename ?? null,
+          dispatchEngine: dispatchResult?.selectedEngine ?? null,
+          dispatchMode: dispatchResult?.mode ?? null,
+          dispatchRequestedMode: dispatchResult?.requestedMode ?? null,
+          dispatchDurationMs: dispatchResult?.durationMs ?? null,
+          dispatchMimeType: dispatchResult?.mimeType ?? null,
+          dispatchExtension: dispatchResult?.fileExtension ?? null,
+          dispatchAttempts: dispatchResult?.attempts.length ?? null,
           remainingBalance: settledRemainingBalance,
           changeState: settledChangeState,
           changeRequested: settledChangeRequested,
@@ -1867,6 +1921,13 @@ export class FinancialService {
             documentId: targetDocumentId ?? null,
             filename: serverFilename ?? null,
             pageRange: printOptions?.pageRange ?? null,
+            dispatchEngine: dispatchResult?.selectedEngine ?? null,
+            dispatchMode: dispatchResult?.mode ?? null,
+            dispatchRequestedMode: dispatchResult?.requestedMode ?? null,
+            dispatchDurationMs: dispatchResult?.durationMs ?? null,
+            dispatchMimeType: dispatchResult?.mimeType ?? null,
+            dispatchExtension: dispatchResult?.fileExtension ?? null,
+            dispatchAttempts: dispatchResult?.attempts.length ?? null,
           },
           onConfirmed: async () => {
             try {

--- a/src/public/admin/system/app.ts
+++ b/src/public/admin/system/app.ts
@@ -438,11 +438,29 @@ testPrintBtn?.addEventListener('click', () => {
         message?: string;
         error?: string;
         printerName?: string;
+        timing?: {
+          totalElapsedMs?: number | null;
+          dispatchDurationMs?: number | null;
+          dispatchEngine?: string | null;
+          dispatchAttempts?: number | null;
+        };
       };
       if (!res.ok || !body.ok) {
         throw new Error(body.error ?? 'Printer unavailable or not connected.');
       }
-      setMessage(body.message ?? 'Test page sent successfully.');
+      const timingParts: string[] = [];
+      if (typeof body.timing?.dispatchEngine === 'string') {
+        timingParts.push(`engine: ${body.timing.dispatchEngine}`);
+      }
+      if (typeof body.timing?.dispatchDurationMs === 'number') {
+        timingParts.push(`dispatch: ${body.timing.dispatchDurationMs}ms`);
+      }
+      if (typeof body.timing?.totalElapsedMs === 'number') {
+        timingParts.push(`total: ${body.timing.totalElapsedMs}ms`);
+      }
+      const timingSuffix =
+        timingParts.length > 0 ? ` (${timingParts.join(', ')})` : '';
+      setMessage((body.message ?? 'Test page sent successfully.') + timingSuffix);
     })
     .catch((e: unknown) =>
       setMessage(e instanceof Error ? e.message : 'Test print failed.'),

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { createCaptivePortalMiddleware, createCsrfProtectionMiddleware } from '@
 import { registerAppModules } from '@/app.module';
 import {
   initDB,
+  assertPrintDispatcherReady,
   detectDefaultPrinter,
   detectScanner,
   startScanStorageCleanup,
@@ -35,6 +36,7 @@ import {
   getPrinterTelemetry,
   startWatchdogHealthMonitor,
   stopWatchdogHealthMonitor,
+  warmPrintDispatcherProfile,
   isCoinSlotLocked,
   getCoinSlotLockOwnerId,
   getCoinSlotLockedAt,
@@ -251,6 +253,8 @@ async function start() {
       });
   }
   await detectDefaultPrinter();
+  await assertPrintDispatcherReady();
+  await warmPrintDispatcherProfile();
   await detectScanner();
   await cleanupTransientFilesOnStartup(UPLOAD_DIR).catch((error) => {
     console.error('[STARTUP] Failed to clean up transient files on startup.', {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -16,7 +16,13 @@ export * from './print-spooler';
 export * from './printer-monitor';
 export * from './printer-fault-lock';
 export type { Orientation, PaperSize, PrintJobOptions } from './printer';
-export { detectDefaultPrinter, printFile } from './printer';
+export type { PrintDispatchContext, PrintDispatchResult } from './printer';
+export {
+  assertPrintDispatcherReady,
+  detectDefaultPrinter,
+  printFile,
+  warmPrintDispatcherProfile,
+} from './printer';
 export * from './printer-status';
 export * from './report-issue';
 export * from './recovery';

--- a/src/services/print-dispatcher.ts
+++ b/src/services/print-dispatcher.ts
@@ -1,0 +1,763 @@
+import { execFile, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import {
+  GHOSTSCRIPT_PATH,
+  LIBREOFFICE_PATH,
+  PDFTOPRINTER_PATH,
+  PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS,
+  PRINT_DISPATCH_MODE,
+  PRINT_DISPATCH_TIMEOUT_MS,
+  type PrintDispatchMode,
+  SUMATRA_PATH,
+} from '@/config';
+import { adminService } from './admin';
+import type { PrintJobOptions } from './printer';
+
+const execFileAsync = promisify(execFile);
+
+export type PrintDispatchEngine =
+  | 'sumatra'
+  | 'pdftoprinter'
+  | 'ghostscript'
+  | 'libreoffice';
+
+export interface PrintDispatchContext {
+  transactionId?: string | null;
+  sessionId?: string | null;
+  documentId?: string | null;
+  spoolerCorrelationKey?: string | null;
+  mode?: 'print' | 'copy' | 'admin-test' | 'legacy-print';
+  source?: string | null;
+}
+
+export interface PrintDispatchAttemptResult {
+  engine: PrintDispatchEngine;
+  executablePath: string | null;
+  success: boolean;
+  skipped: boolean;
+  skipReason: string | null;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  stderrHash: string | null;
+  durationMs: number;
+  startedAt: string;
+  endedAt: string;
+  timedOut: boolean;
+}
+
+export interface PrintDispatchResult {
+  success: boolean;
+  selectedEngine: PrintDispatchEngine | null;
+  mode: PrintDispatchMode;
+  requestedMode: PrintDispatchMode;
+  fileExtension: string;
+  mimeType: string;
+  attempts: PrintDispatchAttemptResult[];
+  durationMs: number;
+}
+
+export class PrintDispatchError extends Error {
+  readonly result: PrintDispatchResult;
+
+  constructor(message: string, result: PrintDispatchResult) {
+    super(message);
+    this.name = 'PrintDispatchError';
+    this.result = result;
+  }
+}
+
+interface ExecutableRunResult {
+  success: boolean;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+const PDF_EXTENSIONS = new Set(['.pdf']);
+const OFFICE_EXTENSIONS = new Set([
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.ppt',
+  '.pptx',
+]);
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png']);
+const SUMATRA_FALLBACK_COMPATIBLE_EXTENSIONS = new Set([
+  '.pdf',
+  '.jpg',
+  '.jpeg',
+  '.png',
+]);
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+};
+
+function normalizeOptional(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readWhereResult(command: string): string | null {
+  const lookup = spawnSync('where.exe', [command], {
+    windowsHide: true,
+    encoding: 'utf8',
+  });
+  if (lookup.status !== 0 || !lookup.stdout) return null;
+  const resolved = lookup.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && fs.existsSync(line));
+  return resolved ?? null;
+}
+
+function coerceStdout(value: string | Buffer | undefined): string {
+  if (typeof value === 'string') return value;
+  if (value == null) return '';
+  return value.toString('utf8');
+}
+
+function hashOrNull(value: string): string | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+}
+
+function parseSimplePageRange(
+  pageRange: string | undefined,
+): { firstPage: number; lastPage: number } | null {
+  if (!pageRange) return null;
+  const trimmed = pageRange.trim();
+  if (!trimmed) return null;
+  const match = /^(\d+)(?:-(\d+))?$/.exec(trimmed);
+  if (!match) return null;
+  const firstPage = Number(match[1]);
+  const lastPage = Number(match[2] ?? match[1]);
+  if (!Number.isInteger(firstPage) || !Number.isInteger(lastPage)) return null;
+  if (firstPage <= 0 || lastPage <= 0 || lastPage < firstPage) return null;
+  return { firstPage, lastPage };
+}
+
+function resolvePaperSizeArg(size: PrintJobOptions['paperSize']): string {
+  if (size === 'Letter') return 'letter';
+  if (size === 'Legal') return 'legal';
+  return 'a4';
+}
+
+function buildSumatraSettings(options: PrintJobOptions): string {
+  const parts: string[] = [];
+  const pageRange = options.pageRange?.trim();
+  if (pageRange) parts.push(pageRange);
+  const copies = Math.max(1, Math.floor(options.copies));
+  if (copies > 1) parts.push(`${copies}x`);
+  parts.push(options.colorMode === 'colored' ? 'color' : 'monochrome');
+  parts.push(options.orientation === 'landscape' ? 'landscape' : 'portrait');
+  if (typeof options.duplex === 'boolean') {
+    parts.push(options.duplex ? 'duplex' : 'simplex');
+  }
+  parts.push(`paper=${options.paperSize}`);
+  return parts.join(',');
+}
+
+export class PrintDispatcher {
+  private cachedPdfToPrinterPath: string | null | undefined;
+  private cachedGhostScriptPath: string | null | undefined;
+  private cachedLibreOfficePath: string | null | undefined;
+  private cachedSumatraPath: string | null | undefined;
+  private activeModeCache: PrintDispatchMode | null = null;
+  private nonProductionFallbackLogged = false;
+
+  private resolveConfiguredPath(
+    configuredPath: string | undefined | null,
+  ): string | null {
+    const normalized = normalizeOptional(configuredPath);
+    if (!normalized) return null;
+    return fs.existsSync(normalized) ? normalized : null;
+  }
+
+  private resolvePdfToPrinterPath(): string | null {
+    if (this.cachedPdfToPrinterPath !== undefined) {
+      return this.cachedPdfToPrinterPath;
+    }
+    this.cachedPdfToPrinterPath = this.resolveConfiguredPath(PDFTOPRINTER_PATH);
+    return this.cachedPdfToPrinterPath;
+  }
+
+  private resolveGhostScriptPath(): string | null {
+    if (this.cachedGhostScriptPath !== undefined) {
+      return this.cachedGhostScriptPath;
+    }
+    const configured = this.resolveConfiguredPath(GHOSTSCRIPT_PATH);
+    if (configured) {
+      this.cachedGhostScriptPath = configured;
+      return configured;
+    }
+    const detected = readWhereResult('gswin64c') ?? readWhereResult('gswin32c');
+    this.cachedGhostScriptPath = detected;
+    return detected;
+  }
+
+  private resolveLibreOfficePath(): string | null {
+    if (this.cachedLibreOfficePath !== undefined) {
+      return this.cachedLibreOfficePath;
+    }
+    const configured = this.resolveConfiguredPath(LIBREOFFICE_PATH);
+    if (configured) {
+      this.cachedLibreOfficePath = configured;
+      return configured;
+    }
+    const candidates = [
+      path.join(
+        process.env.ProgramFiles ?? '',
+        'LibreOffice',
+        'program',
+        'soffice.exe',
+      ),
+      path.join(
+        process.env['ProgramFiles(x86)'] ?? '',
+        'LibreOffice',
+        'program',
+        'soffice.exe',
+      ),
+      path.join(
+        process.env.ProgramFiles ?? '',
+        'LibreOffice',
+        'program',
+        'soffice.com',
+      ),
+      path.join(
+        process.env['ProgramFiles(x86)'] ?? '',
+        'LibreOffice',
+        'program',
+        'soffice.com',
+      ),
+    ];
+    const localFound = candidates.find((candidate) => fs.existsSync(candidate));
+    if (localFound) {
+      this.cachedLibreOfficePath = localFound;
+      return localFound;
+    }
+    const detected = readWhereResult('soffice');
+    this.cachedLibreOfficePath = detected;
+    return detected;
+  }
+
+  private resolveSumatraPath(): string | null {
+    if (this.cachedSumatraPath !== undefined) {
+      return this.cachedSumatraPath;
+    }
+    this.cachedSumatraPath = this.resolveConfiguredPath(SUMATRA_PATH);
+    return this.cachedSumatraPath;
+  }
+
+  private resolveNewStackMissingDependencies(): string[] {
+    const missing: string[] = [];
+    if (!this.resolvePdfToPrinterPath()) missing.push('PDFtoPrinter');
+    if (!this.resolveGhostScriptPath()) missing.push('GhostScript');
+    if (!this.resolveLibreOfficePath()) missing.push('LibreOffice');
+    return missing;
+  }
+
+  private isProduction(): boolean {
+    return process.env.NODE_ENV?.trim().toLowerCase() === 'production';
+  }
+
+  private getActiveMode(): PrintDispatchMode {
+    if (this.activeModeCache) return this.activeModeCache;
+    if (PRINT_DISPATCH_MODE === 'legacy') {
+      this.activeModeCache = 'legacy';
+      return this.activeModeCache;
+    }
+
+    const missing = this.resolveNewStackMissingDependencies();
+    if (missing.length === 0) {
+      this.activeModeCache = PRINT_DISPATCH_MODE;
+      return this.activeModeCache;
+    }
+
+    const details = `Missing print dependencies: ${missing.join(', ')}. Requested mode=${PRINT_DISPATCH_MODE}.`;
+    if (this.isProduction()) {
+      throw new Error(
+        `[PRINT_DISPATCH] ${details} Set paths for PDFtoPrinter, GhostScript, and LibreOffice before startup.`,
+      );
+    }
+
+    if (!this.nonProductionFallbackLogged) {
+      this.nonProductionFallbackLogged = true;
+      console.warn(
+        `[PRINT_DISPATCH] ${details} Falling back to legacy Sumatra mode for local/dev.`,
+      );
+    }
+    this.activeModeCache = 'legacy';
+    return this.activeModeCache;
+  }
+
+  async assertReady(): Promise<void> {
+    void this.getActiveMode();
+    if (this.getActiveMode() !== 'legacy' && !this.resolveSumatraPath()) {
+      // Sumatra is used as emergency fallback in phased mode.
+      console.warn(
+        '[PRINT_DISPATCH] Sumatra fallback is unavailable (SUMATRA_PATH not found).',
+      );
+    }
+  }
+
+  async warmLibreOfficeProfile(): Promise<void> {
+    const mode = this.getActiveMode();
+    if (mode === 'legacy') return;
+    const sofficePath = this.resolveLibreOfficePath();
+    if (!sofficePath) return;
+
+    const warmupTimeoutMs = Math.max(
+      10_000,
+      Math.min(20_000, PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS),
+    );
+    const startedAt = Date.now();
+    try {
+      await execFileAsync(
+        sofficePath,
+        ['--headless', '--nologo', '--nodefault', '--version'],
+        {
+          windowsHide: true,
+          timeout: warmupTimeoutMs,
+        },
+      );
+      console.log(
+        `[PRINT_DISPATCH] LibreOffice warm-up completed in ${Date.now() - startedAt}ms`,
+      );
+    } catch (error) {
+      console.warn('[PRINT_DISPATCH] LibreOffice warm-up failed.', {
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private resolveMimeFromExtension(extension: string): string {
+    return MIME_BY_EXTENSION[extension] ?? 'application/octet-stream';
+  }
+
+  private resolveEngineChain(
+    extension: string,
+    mode: PrintDispatchMode,
+  ): PrintDispatchEngine[] {
+    if (mode === 'legacy') {
+      return ['sumatra'];
+    }
+    if (PDF_EXTENSIONS.has(extension)) {
+      return mode === 'phased'
+        ? ['pdftoprinter', 'ghostscript', 'sumatra']
+        : ['pdftoprinter', 'ghostscript'];
+    }
+    if (OFFICE_EXTENSIONS.has(extension) || IMAGE_EXTENSIONS.has(extension)) {
+      if (mode === 'phased' && SUMATRA_FALLBACK_COMPATIBLE_EXTENSIONS.has(extension)) {
+        return ['libreoffice', 'sumatra'];
+      }
+      return ['libreoffice'];
+    }
+    return mode === 'phased' ? ['libreoffice', 'sumatra'] : ['libreoffice'];
+  }
+
+  private async executeCommand(
+    executablePath: string,
+    args: string[],
+    timeoutMs: number,
+  ): Promise<ExecutableRunResult> {
+    return new Promise((resolve) => {
+      execFile(
+        executablePath,
+        args,
+        { windowsHide: true, timeout: timeoutMs },
+        (error, stdout, stderr) => {
+          const normalizedStdout = coerceStdout(stdout);
+          const normalizedStderr = coerceStdout(stderr);
+          if (!error) {
+            resolve({
+              success: true,
+              exitCode: 0,
+              stdout: normalizedStdout,
+              stderr: normalizedStderr,
+              timedOut: false,
+            });
+            return;
+          }
+
+          const err = error as NodeJS.ErrnoException & {
+            code?: string | number;
+            signal?: NodeJS.Signals;
+            killed?: boolean;
+          };
+          const exitCode = typeof err.code === 'number' ? err.code : null;
+          const timedOut =
+            err.code === 'ETIMEDOUT' ||
+            (err.killed === true && err.signal === 'SIGTERM');
+          resolve({
+            success: false,
+            exitCode,
+            stdout: normalizedStdout,
+            stderr: normalizedStderr,
+            timedOut,
+          });
+        },
+      );
+    });
+  }
+
+  private async logAttempt(
+    attempt: PrintDispatchAttemptResult,
+    extension: string,
+    mimeType: string,
+    context: PrintDispatchContext,
+  ): Promise<void> {
+    await adminService.appendAdminLog(
+      'print_dispatch_attempt',
+      attempt.success
+        ? `Print dispatch attempt succeeded via ${attempt.engine}.`
+        : attempt.skipped
+          ? `Print dispatch attempt skipped for ${attempt.engine}.`
+          : `Print dispatch attempt failed via ${attempt.engine}.`,
+      {
+        transactionId: normalizeOptional(context.transactionId),
+        sessionId: normalizeOptional(context.sessionId),
+        documentId: normalizeOptional(context.documentId),
+        spoolerCorrelationKey: normalizeOptional(context.spoolerCorrelationKey),
+        mode: context.mode ?? null,
+        source: normalizeOptional(context.source),
+        engine: attempt.engine,
+        executablePath: attempt.executablePath,
+        success: attempt.success,
+        skipped: attempt.skipped,
+        skipReason: attempt.skipReason,
+        exitCode: attempt.exitCode,
+        durationMs: attempt.durationMs,
+        timedOut: attempt.timedOut,
+        fileExtension: extension,
+        mimeType,
+        stderrHash: attempt.stderrHash,
+      },
+    );
+  }
+
+  private async runAttempt(
+    engine: PrintDispatchEngine,
+    filePath: string,
+    options: PrintJobOptions,
+  ): Promise<PrintDispatchAttemptResult> {
+    const startedAt = new Date().toISOString();
+    const startedMs = Date.now();
+    const skip = (skipReason: string): PrintDispatchAttemptResult => ({
+      engine,
+      executablePath: null,
+      success: false,
+      skipped: true,
+      skipReason,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      stderrHash: null,
+      durationMs: 0,
+      startedAt,
+      endedAt: new Date().toISOString(),
+      timedOut: false,
+    });
+
+    if (engine === 'pdftoprinter') {
+      const executablePath = this.resolvePdfToPrinterPath();
+      if (!executablePath) return skip('pdftoprinter_missing');
+      // PDFtoPrinter is kept as a lightweight handoff tool; advanced options use GhostScript.
+      if (
+        options.copies > 1 ||
+        Boolean(options.pageRange?.trim()) ||
+        options.duplex === true
+      ) {
+        return skip('pdftoprinter_unsupported_advanced_options');
+      }
+      const args = [filePath];
+      if (options.printerName?.trim()) {
+        args.push(options.printerName.trim());
+      }
+      const runResult = await this.executeCommand(
+        executablePath,
+        args,
+        PRINT_DISPATCH_TIMEOUT_MS,
+      );
+      const endedAt = new Date().toISOString();
+      return {
+        engine,
+        executablePath,
+        success: runResult.success,
+        skipped: false,
+        skipReason: null,
+        exitCode: runResult.exitCode,
+        stdout: runResult.stdout,
+        stderr: runResult.stderr,
+        stderrHash: hashOrNull(runResult.stderr),
+        durationMs: Date.now() - startedMs,
+        startedAt,
+        endedAt,
+        timedOut: runResult.timedOut,
+      };
+    }
+
+    if (engine === 'ghostscript') {
+      const executablePath = this.resolveGhostScriptPath();
+      if (!executablePath) return skip('ghostscript_missing');
+      const printerTarget = options.printerName?.trim()
+        ? `%printer%${options.printerName.trim()}`
+        : '%printer%';
+      const args = [
+        '-dPrinted',
+        '-dBATCH',
+        '-dNOPAUSE',
+        '-dNOSAFER',
+        '-sDEVICE=mswinpr2',
+        `-sOutputFile=${printerTarget}`,
+        `-sPAPERSIZE=${resolvePaperSizeArg(options.paperSize)}`,
+      ];
+      if (options.copies > 1) {
+        args.push(`-dNumCopies=${Math.max(1, Math.floor(options.copies))}`);
+      }
+      if (options.duplex === true) args.push('-dDuplex');
+      if (options.duplex === false) args.push('-dSimplex');
+      if (options.colorMode === 'grayscale') {
+        args.push(
+          '-sColorConversionStrategy=Gray',
+          '-dProcessColorModel=/DeviceGray',
+        );
+      }
+      const range = parseSimplePageRange(options.pageRange);
+      if (range) {
+        args.push(`-dFirstPage=${range.firstPage}`, `-dLastPage=${range.lastPage}`);
+      }
+      args.push(filePath);
+      const runResult = await this.executeCommand(
+        executablePath,
+        args,
+        PRINT_DISPATCH_TIMEOUT_MS,
+      );
+      const endedAt = new Date().toISOString();
+      return {
+        engine,
+        executablePath,
+        success: runResult.success,
+        skipped: false,
+        skipReason: null,
+        exitCode: runResult.exitCode,
+        stdout: runResult.stdout,
+        stderr: runResult.stderr,
+        stderrHash: hashOrNull(runResult.stderr),
+        durationMs: Date.now() - startedMs,
+        startedAt,
+        endedAt,
+        timedOut: runResult.timedOut,
+      };
+    }
+
+    if (engine === 'libreoffice') {
+      const executablePath = this.resolveLibreOfficePath();
+      if (!executablePath) return skip('libreoffice_missing');
+      const printerName = options.printerName?.trim();
+      if (!printerName) return skip('libreoffice_missing_printer_name');
+      // LibreOffice --pt does not expose robust per-job advanced controls here.
+      if (
+        options.copies > 1 ||
+        Boolean(options.pageRange?.trim()) ||
+        options.duplex === true
+      ) {
+        return skip('libreoffice_unsupported_advanced_options');
+      }
+      const args = [
+        '--headless',
+        '--nologo',
+        '--nodefault',
+        '--norestore',
+        '--nolockcheck',
+        '--pt',
+        printerName,
+        filePath,
+      ];
+      const runResult = await this.executeCommand(
+        executablePath,
+        args,
+        PRINT_DISPATCH_LIBREOFFICE_TIMEOUT_MS,
+      );
+      const endedAt = new Date().toISOString();
+      return {
+        engine,
+        executablePath,
+        success: runResult.success,
+        skipped: false,
+        skipReason: null,
+        exitCode: runResult.exitCode,
+        stdout: runResult.stdout,
+        stderr: runResult.stderr,
+        stderrHash: hashOrNull(runResult.stderr),
+        durationMs: Date.now() - startedMs,
+        startedAt,
+        endedAt,
+        timedOut: runResult.timedOut,
+      };
+    }
+
+    const executablePath = this.resolveSumatraPath();
+    if (!executablePath) return skip('sumatra_missing');
+    const settings = buildSumatraSettings(options);
+    const args = options.printerName?.trim()
+      ? [
+          '-silent',
+          '-print-to',
+          options.printerName.trim(),
+          '-print-settings',
+          settings,
+          filePath,
+        ]
+      : ['-silent', '-print-to-default', '-print-settings', settings, filePath];
+    const runResult = await this.executeCommand(
+      executablePath,
+      args,
+      PRINT_DISPATCH_TIMEOUT_MS,
+    );
+    const endedAt = new Date().toISOString();
+    return {
+      engine,
+      executablePath,
+      success: runResult.success,
+      skipped: false,
+      skipReason: null,
+      exitCode: runResult.exitCode,
+      stdout: runResult.stdout,
+      stderr: runResult.stderr,
+      stderrHash: hashOrNull(runResult.stderr),
+      durationMs: Date.now() - startedMs,
+      startedAt,
+      endedAt,
+      timedOut: runResult.timedOut,
+    };
+  }
+
+  async dispatchFile(
+    filePath: string,
+    options: PrintJobOptions,
+    context: PrintDispatchContext = {},
+  ): Promise<PrintDispatchResult> {
+    const requestedMode = PRINT_DISPATCH_MODE;
+    const mode = this.getActiveMode();
+    const extension = path.extname(filePath).toLowerCase();
+    const mimeType = this.resolveMimeFromExtension(extension);
+    const engineChain = this.resolveEngineChain(extension, mode);
+    const overallStartMs = Date.now();
+    const attempts: PrintDispatchAttemptResult[] = [];
+
+    for (const engine of engineChain) {
+      const attempt = await this.runAttempt(engine, filePath, options);
+      attempts.push(attempt);
+      await this.logAttempt(attempt, extension, mimeType, context).catch(
+        (error) => {
+          console.error('[PRINT_DISPATCH] Failed to write dispatch attempt log.', {
+            engine,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+      );
+      if (attempt.success) {
+        const result: PrintDispatchResult = {
+          success: true,
+          selectedEngine: engine,
+          mode,
+          requestedMode,
+          fileExtension: extension,
+          mimeType,
+          attempts,
+          durationMs: Date.now() - overallStartMs,
+        };
+        await adminService
+          .appendAdminLog(
+            'print_dispatch_summary',
+            `Print dispatch succeeded via ${engine}.`,
+            {
+              transactionId: normalizeOptional(context.transactionId),
+              sessionId: normalizeOptional(context.sessionId),
+              documentId: normalizeOptional(context.documentId),
+              spoolerCorrelationKey: normalizeOptional(
+                context.spoolerCorrelationKey,
+              ),
+              mode: context.mode ?? null,
+              source: normalizeOptional(context.source),
+              dispatchMode: mode,
+              requestedDispatchMode: requestedMode,
+              selectedEngine: engine,
+              attempts: attempts.length,
+              durationMs: result.durationMs,
+              fileExtension: extension,
+              mimeType,
+              fallbackUsed: attempts.length > 1,
+            },
+          )
+          .catch((error) => {
+            console.error('[PRINT_DISPATCH] Failed to write dispatch summary log.', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+        return result;
+      }
+    }
+
+    const result: PrintDispatchResult = {
+      success: false,
+      selectedEngine: null,
+      mode,
+      requestedMode,
+      fileExtension: extension,
+      mimeType,
+      attempts,
+      durationMs: Date.now() - overallStartMs,
+    };
+    await adminService
+      .appendAdminLog('print_dispatch_summary', 'Print dispatch failed.', {
+        transactionId: normalizeOptional(context.transactionId),
+        sessionId: normalizeOptional(context.sessionId),
+        documentId: normalizeOptional(context.documentId),
+        spoolerCorrelationKey: normalizeOptional(context.spoolerCorrelationKey),
+        mode: context.mode ?? null,
+        source: normalizeOptional(context.source),
+        dispatchMode: mode,
+        requestedDispatchMode: requestedMode,
+        selectedEngine: null,
+        attempts: attempts.length,
+        durationMs: result.durationMs,
+        fileExtension: extension,
+        mimeType,
+      })
+      .catch((error) => {
+        console.error('[PRINT_DISPATCH] Failed to write dispatch failure summary.', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    throw new PrintDispatchError('Print dispatch failed across all engines.', result);
+  }
+}
+
+export const printDispatcher = new PrintDispatcher();
+
+export const assertPrintDispatcherReady =
+  printDispatcher.assertReady.bind(printDispatcher);
+
+export const warmPrintDispatcherProfile =
+  printDispatcher.warmLibreOfficeProfile.bind(printDispatcher);

--- a/src/services/print-spooler.ts
+++ b/src/services/print-spooler.ts
@@ -20,7 +20,7 @@ const JOB_LOOKBACK_MINUTES = 3;
 /** Allowed clock skew between app dispatch time and spooler submitted time */
 const JOB_SUBMITTED_TIME_SKEW_MS = 5_000;
 /** Timeout per individual PowerShell query */
-const SPOOLER_QUERY_TIMEOUT_MS = 10_000;
+const SPOOLER_QUERY_TIMEOUT_MS = 20_000;
 /** Stop monitoring when spooler queries repeatedly fail */
 const MAX_CONSECUTIVE_QUERY_FAILURES = 3;
 
@@ -324,6 +324,7 @@ export async function monitorSpoolerJob(
   let pollCount = 0;
   let queryFailureCount = 0;
   let consecutiveQueryFailures = 0;
+  let psRestartCount = 0;
   let lastQueryErrorCode: SpoolerQueryErrorCode | null = null;
   let lastQueryErrorDetail: string | null = null;
   let lastQueryElapsedMs = 0;
@@ -337,6 +338,7 @@ export async function monitorSpoolerJob(
       monitorPollCount: pollCount,
       spoolerQueryFailureCount: queryFailureCount,
       spoolerConsecutiveQueryFailures: consecutiveQueryFailures,
+      spoolerPsRestartCount: psRestartCount,
       spoolerLastQueryElapsedMs: lastQueryElapsedMs,
     };
     if (handoffLatencyMs !== null) {
@@ -456,7 +458,25 @@ export async function monitorSpoolerJob(
   let trackedJobId: number | null = null;
   let warnedSubmittedTimeFallback = false;
 
-  const ps = createPersistentPS();
+  let ps = createPersistentPS();
+  const restartPersistentPs = (
+    reason: string,
+    errorCode: SpoolerQueryErrorCode,
+    errorDetail: string | null,
+  ): void => {
+    ps.dispose();
+    ps = createPersistentPS();
+    psRestartCount += 1;
+    console.warn('[SPOOLER-MONITOR] Restarted PowerShell runspace.', {
+      transactionId,
+      spoolerCorrelationKey: correlationKey,
+      printerName: normalizedPrinterName,
+      reason,
+      errorCode,
+      errorDetail,
+      psRestartCount,
+    });
+  };
 
   const settleMonitorAmbiguity = async (
     reason: string,
@@ -609,6 +629,19 @@ export async function monitorSpoolerJob(
           errorCode: queryResult.errorCode,
           errorDetail: queryResult.errorDetail,
         });
+        const recoverablePsFailure =
+          queryResult.errorCode === 'powershell_timeout' ||
+          (queryResult.errorCode === 'query_failed' &&
+            (queryResult.errorDetail ?? '').includes(
+              'PS runspace already disposed',
+            ));
+        if (recoverablePsFailure) {
+          restartPersistentPs(
+            'recoverable_query_failure',
+            queryResult.errorCode,
+            queryResult.errorDetail,
+          );
+        }
         if (consecutiveQueryFailures >= MAX_CONSECUTIVE_QUERY_FAILURES) {
           const reason =
             'Spooler monitoring aborted due to repeated spooler query failures.';

--- a/src/services/print-spooler.ts
+++ b/src/services/print-spooler.ts
@@ -866,6 +866,30 @@ export async function monitorSpoolerJob(
             );
           }
         }
+        try {
+          await adminService.appendAdminLog(
+            'print_spooler_confirmed',
+            `Print spooler confirmed successful print: ${job.status}.`,
+            {
+              spoolerJobId: job.id,
+              spoolerStatus: job.status,
+              pagesPrinted: job.pagesPrinted,
+              totalPages: job.totalPages,
+              printerName: normalizedPrinterName,
+              transactionId,
+              spoolerCorrelationKey: correlationKey,
+              monitorElapsedMs: Date.now() - startedAtMs,
+              handoffLatencyMs,
+              pollCount,
+              queryFailureCount,
+            },
+          );
+        } catch (error) {
+          console.error(
+            '[SPOOLER-MONITOR] Failed to append spooler confirmed admin log.',
+            error,
+          );
+        }
         if (onConfirmed) {
           try {
             await onConfirmed({

--- a/src/services/printer.ts
+++ b/src/services/printer.ts
@@ -1,6 +1,14 @@
 import { execFile } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
+import { SUMATRA_PATH } from '@/config';
+import {
+  assertPrintDispatcherReady,
+  printDispatcher,
+  warmPrintDispatcherProfile,
+  type PrintDispatchContext,
+  type PrintDispatchResult,
+} from './print-dispatcher';
 
 export type ColorMode = 'colored' | 'grayscale';
 export type Orientation = 'portrait' | 'landscape';
@@ -13,21 +21,22 @@ export interface PrintJobOptions {
   paperSize: PaperSize;
   pageRange?: string;
   duplex?: boolean;
+  printerName?: string;
 }
 
 export class PrinterService {
   private readonly sumatraPath: string;
 
   constructor() {
-    this.sumatraPath = path.resolve('bin', 'SumatraPDF.exe');
+    this.sumatraPath = SUMATRA_PATH;
   }
 
   async detectDefaultPrinter(): Promise<void> {
-    console.log('[PRINTER] ── Detecting default printer ─────────────────');
+    console.log('[PRINTER] -- Detecting default printer ------------------------');
 
     const sumatraExists = fs.existsSync(this.sumatraPath);
     console.log(
-      `[PRINTER] SumatraPDF: ${this.sumatraPath} (exists: ${sumatraExists})`,
+      `[PRINTER] Sumatra fallback: ${this.sumatraPath} (exists: ${sumatraExists})`,
     );
 
     try {
@@ -48,7 +57,7 @@ export class PrinterService {
       });
 
       if (!json) {
-        console.log('[PRINTER] ✗ No default printer set — printing will fail');
+        console.log('[PRINTER] No default printer set; printing will fail.');
         return;
       }
 
@@ -59,148 +68,62 @@ export class PrinterService {
         PrinterStatus: number;
       };
 
-      console.log('[PRINTER] ✓ Default printer queue found in Windows:');
+      console.log('[PRINTER] Default printer queue found in Windows:');
       console.log(`[PRINTER]   Name: ${printer.Name}`);
       console.log(`[PRINTER]   Driver: ${printer.DriverName}`);
       console.log(`[PRINTER]   Port: ${printer.PortName}`);
       console.log(`[PRINTER]   Status code: ${printer.PrinterStatus}`);
       console.log(
-        '[PRINTER]   Note: This confirms Windows default printer/driver registration.',
-      );
-      console.log(
-        '[PRINTER]   Note: Physical readiness (online/paper/ink) is evaluated by printer telemetry.',
+        '[PRINTER]   Physical readiness is still validated by runtime printer telemetry.',
       );
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.log(`[PRINTER] ⚠ Could not detect printer: ${msg}`);
+      console.log(`[PRINTER] Could not detect default printer: ${msg}`);
     }
   }
 
-  private buildPrintSettings(options: PrintJobOptions): string {
-    const parts: string[] = [];
-
-    const pageRange = options.pageRange?.trim();
-    if (pageRange) parts.push(pageRange);
-
-    const copies = Math.max(1, Math.floor(options.copies));
-    if (copies > 1) parts.push(`${copies}x`);
-
-    parts.push(options.colorMode === 'colored' ? 'color' : 'monochrome');
-    parts.push(options.orientation === 'landscape' ? 'landscape' : 'portrait');
-    if (typeof options.duplex === 'boolean') {
-      parts.push(options.duplex ? 'duplex' : 'simplex');
+  async printFile(
+    filename: string,
+    options: PrintJobOptions,
+    context: PrintDispatchContext = {},
+  ): Promise<PrintDispatchResult> {
+    const uploadsDir = path.resolve('uploads');
+    const normalizedFilename = filename.trim();
+    if (!normalizedFilename) {
+      throw new Error('Invalid filename');
     }
-    parts.push(`paper=${options.paperSize}`);
 
-    return parts.join(',');
-  }
+    const filePath = path.resolve(uploadsDir, normalizedFilename);
+    const relativePath = path.relative(uploadsDir, filePath);
+    const outsideUploads =
+      relativePath === '..' ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath);
+    if (outsideUploads) {
+      throw new Error('Invalid filename');
+    }
 
-  printFile(filename: string, options: PrintJobOptions): Promise<void> {
-    console.log('[PRINTER] ── New print job ──────────────────────────');
-    console.log('[PRINTER] File:', filename);
-    console.log('[PRINTER] Options:', JSON.stringify(options, null, 2));
-
-    return new Promise((resolve, reject) => {
-      const uploadsDir = path.resolve('uploads');
-      const normalizeFilename = filename.trim();
-      if (!normalizeFilename) {
-        console.error('[PRINTER] ✗ Invalid filename — empty string');
-        return reject(new Error('Invalid filename'));
+    const fileExists = fs.existsSync(filePath);
+    if (fileExists && !fs.statSync(filePath).isFile()) {
+      throw new Error('Invalid filename');
+    }
+    if (fileExists) {
+      const realUploadsDir = fs.realpathSync(uploadsDir);
+      const realFilePath = fs.realpathSync(filePath);
+      const realRelative = path.relative(realUploadsDir, realFilePath);
+      const realOutsideUploads =
+        realRelative === '..' ||
+        realRelative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(realRelative);
+      if (realOutsideUploads) {
+        throw new Error('Invalid filename');
       }
-      const filePath = path.resolve(uploadsDir, normalizeFilename);
-      const relativePath = path.relative(uploadsDir, filePath);
-      const outsideUploads =
-        relativePath === '..' ||
-        relativePath.startsWith(`..${path.sep}`) ||
-        path.isAbsolute(relativePath);
-      if (outsideUploads) {
-        console.error(
-          '[PRINTER] ✗ Invalid filename — outside uploads directory',
-        );
-        return reject(new Error('Invalid filename'));
-      }
-      const fileExists = fs.existsSync(filePath);
-      if (fileExists && !fs.statSync(filePath).isFile()) {
-        console.error('[PRINTER] ✗ Invalid filename — not a file');
-        return reject(new Error('Invalid filename'));
-      }
-      if (fileExists) {
-        const realUploadsDir = fs.realpathSync(uploadsDir);
-        const realFilePath = fs.realpathSync(filePath);
-        const realRelative = path.relative(realUploadsDir, realFilePath);
-        const realOutsideUploads =
-          realRelative === '..' ||
-          realRelative.startsWith(`..${path.sep}`) ||
-          path.isAbsolute(realRelative);
-        if (realOutsideUploads) {
-          console.error(
-            '[PRINTER] ✗ Invalid filename — resolved outside uploads directory',
-          );
-          return reject(new Error('Invalid filename'));
-        }
-      }
-      console.log(
-        `[PRINTER] Resolved path: ${filePath} (exists: ${fileExists})`,
-      );
+    }
+    if (!fileExists) {
+      throw new Error(`File not found: ${filePath}`);
+    }
 
-      if (!fileExists) {
-        console.error('[PRINTER] ✗ File not found — aborting');
-        return reject(new Error(`File not found: ${filePath}`));
-      }
-
-      const sumatraExists = fs.existsSync(this.sumatraPath);
-      console.log(
-        `[PRINTER] SumatraPDF path: ${this.sumatraPath} (exists: ${sumatraExists})`,
-      );
-
-      if (!sumatraExists) {
-        console.error('[PRINTER] ✗ SumatraPDF not found — aborting');
-        return reject(
-          new Error(
-            `SumatraPDF not found at ${this.sumatraPath}. Place the portable exe in bin/.`,
-          ),
-        );
-      }
-
-      const settings = this.buildPrintSettings(options);
-      console.log(`[PRINTER] Settings string: "${settings}"`);
-
-      const args = [
-        '-silent',
-        '-print-to-default',
-        '-print-settings',
-        settings,
-        filePath,
-      ];
-      console.log(`[PRINTER] Executing: ${this.sumatraPath} ${args.join(' ')}`);
-
-      const startMs = Date.now();
-      execFile(
-        this.sumatraPath,
-        args,
-        { timeout: 60_000, windowsHide: true },
-        (error, stdout, stderr) => {
-          const elapsed = Date.now() - startMs;
-
-          if (stdout) console.log(`[PRINTER] stdout: ${stdout}`);
-          if (stderr) console.warn(`[PRINTER] stderr: ${stderr}`);
-
-          if (error) {
-            console.error(
-              `[PRINTER] ✗ Print failed after ${elapsed}ms: ${error.message}`,
-            );
-            return reject(
-              new Error(
-                `Print failed: ${error.message}${stderr ? ` — ${stderr}` : ''}`,
-              ),
-            );
-          }
-
-          console.log(`[PRINTER] ✓ Print job sent to spooler in ${elapsed}ms`);
-          resolve();
-        },
-      );
-    });
+    return printDispatcher.dispatchFile(filePath, options, context);
   }
 }
 
@@ -208,3 +131,5 @@ export const printerService = new PrinterService();
 export const detectDefaultPrinter =
   printerService.detectDefaultPrinter.bind(printerService);
 export const printFile = printerService.printFile.bind(printerService);
+export { assertPrintDispatcherReady, warmPrintDispatcherProfile };
+export type { PrintDispatchContext, PrintDispatchResult };

--- a/src/services/test-page.ts
+++ b/src/services/test-page.ts
@@ -3,8 +3,8 @@
  * No npm dependencies. Uses the standard Type1 Helvetica font (always available
  * in PDF readers and print drivers — no font embedding needed).
  *
- * The resulting PDF is suitable for printing via SumatraPDF to verify a printer
- * is correctly installed and producing output after setup or replacement.
+ * The resulting PDF is suitable for validating printer output through the
+ * configured PrintBit print dispatcher path after setup or replacement.
  */
 
 /**
@@ -70,7 +70,7 @@ export function generateTestPagePdf(now: Date = new Date()): Buffer {
     S(68, 636, '- Printer power, USB/network cable, and driver installation'),
     S(68, 620, '- Default printer is set correctly in Windows Settings'),
     S(68, 604, '- No paper jam or paper-out condition'),
-    S(68, 588, '- SumatraPDF is present at bin/SumatraPDF.exe'),
+    S(68, 588, '- Print dispatcher dependencies are configured for this kiosk'),
 
     // ── Checklist ──────────────────────────────────────────────────────────
     S(50, 564, '-'.repeat(62)),

--- a/src/services/time-source.ts
+++ b/src/services/time-source.ts
@@ -50,7 +50,7 @@ let statusCache: TrustedTimeStatus = {
   offsetMs: null,
   driftExceeded: false,
   maxDriftMs: DEFAULT_MAX_DRIFT_MS,
-  enforceForFinancial: true,
+  enforceForFinancial: false,
   checkedAt: new Date(0).toISOString(),
   detail: 'Trusted time has not been verified yet.',
   ntpSource: null,
@@ -91,9 +91,10 @@ function readEnforceFlag(): boolean {
     }
     return true;
   }
-  // ESP32 deployments are commonly offline-only, so strict trusted-time
-  // enforcement must be opt-in there to avoid blocking kiosk payments/prints.
-  return process.env.PRINTBIT_NETWORK_PROVIDER?.trim().toLowerCase() !== 'esp32';
+  // Trusted-time enforcement is opt-in by default. Many production kiosks run
+  // in offline/limited-connectivity environments and should not block
+  // payments, refunds, or recovery on NTP availability.
+  return false;
 }
 
 function readNtpServerOverride(): string | null {

--- a/src/services/time-source.ts
+++ b/src/services/time-source.ts
@@ -83,7 +83,17 @@ function readRevalidationIntervalMs(): number {
 }
 
 function readEnforceFlag(): boolean {
-  return process.env.PRINTBIT_TRUSTED_TIME_ENFORCE !== 'false';
+  const raw = process.env.PRINTBIT_TRUSTED_TIME_ENFORCE;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+      return false;
+    }
+    return true;
+  }
+  // ESP32 deployments are commonly offline-only, so strict trusted-time
+  // enforcement must be opt-in there to avoid blocking kiosk payments/prints.
+  return process.env.PRINTBIT_NETWORK_PROVIDER?.trim().toLowerCase() !== 'esp32';
 }
 
 function readNtpServerOverride(): string | null {
@@ -279,6 +289,7 @@ export function assertTrustedTimeForFinancialOperation(
   operation: string,
 ): void {
   const status = getTrustedTimeStatus();
+  if (!status.enforceForFinancial) return;
   const ageMs = Date.now() - Date.parse(status.checkedAt);
   const staleThresholdMs = readRevalidationIntervalMs();
   if (!Number.isFinite(ageMs) || ageMs > staleThresholdMs) {
@@ -292,7 +303,6 @@ export function assertTrustedTimeForFinancialOperation(
         'Trusted time status is stale. Wait for the next verification cycle or run a manual time-sync check.',
     });
   }
-  if (!status.enforceForFinancial) return;
   if (!status.synced || status.offsetMs === null || status.driftExceeded) {
     throw new TrustedTimeError(operation, status);
   }


### PR DESCRIPTION
# #112 Implemented Replacing SumatraPDF of another Print Dispatch of Choice

This pull request updates documentation across the project to support the new phased print dispatcher architecture, which replaces the legacy SumatraPDF-only print integration with a mode-based dispatcher supporting PDFtoPrinter, GhostScript, LibreOffice, and optional Sumatra fallback. It introduces new configuration options, updates installation and troubleshooting instructions, and adds operational guidance for phased rollout and cutover. Additionally, a new API endpoint for print dispatch latency analytics is documented, and a detailed migration design specification is included.

**Print Dispatcher Migration and Configuration**

- Updated all documentation (`README.md`, `INSTALLATIONS.md`, `OPERATIONS.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `WINDOWS_KIOSK_LOCKDOWN_SETUP.md`) to describe the new mode-based print dispatcher, its supported engines (PDFtoPrinter, GhostScript, LibreOffice, and optional Sumatra fallback), and related environment variables for configuration and timeouts. This includes detailed setup, troubleshooting, and preflight checklists for each mode. 
- Added a new section to `README.md` explaining the dispatcher configuration, modes (`legacy`, `phased`, `new-only`), and all relevant environment variables.

**Operational and Rollout Guidance**

- Added operational guidance in `OPERATIONS.md` for phased dispatcher rollout, including criteria for moving from `phased` to `new-only`, rollback instructions, and use of the new latency analytics endpoint for cutover readiness.
- Included a new design specification document (`docs/superpowers/specs/2026-04-09-print-dispatcher-sumatra-replacement-design.md`) detailing the migration strategy, architecture, configuration, error handling, observability, and test plan for the phased dispatcher rollout.

**API Documentation Enhancements**

- Documented a new API endpoint `GET /api/admin/print-dispatch/latency` in `API_DOCUMENTATION.md` for print dispatcher latency analytics, including response structure and speculation logic for non-PDF slowness.
- Updated the test print endpoint documentation to include detailed timing metadata for dispatch attempts.

**General Improvements**

- Standardized type-check instructions across all docs to use `pnpm exec tsc --noEmit --ignoreDeprecations 6.0`. 
- Clarified external dependency requirements and updated troubleshooting steps to reflect the new dispatcher and engine binaries. 

**Other Updates**

- Added documentation for the new trusted time enforcement environment variable for ESP32 mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin endpoint for print-dispatch latency analytics with percentile metrics and performance speculation.
  * Test-print now returns dispatch timing, engine and attempt details.
  * Authenticated hopper dispense/status endpoints for coin hopper control.

* **Configuration**
  * New print-dispatcher mode and environment variables for engine binaries and dispatcher timeouts.
  * Trusted-time enforcement behavior made configurable.

* **Documentation**
  * Updated README, install, ops, contribution and kiosk docs plus a new phased print-dispatcher design spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->